### PR TITLE
feat: add Dockerfile for running Claude Code in a container

### DIFF
--- a/Dockerfile.claude-code
+++ b/Dockerfile.claude-code
@@ -1,0 +1,58 @@
+FROM node:20-bookworm
+
+# System dependencies: dev tools + firewall
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    jq \
+    fzf \
+    less \
+    vim \
+    sudo \
+    direnv \
+    iptables \
+    ipset \
+    iproute2 \
+    dnsutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bazelisk (project build tool)
+RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 \
+      -o /usr/local/bin/bazelisk \
+    && chmod +x /usr/local/bin/bazelisk \
+    && ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
+
+# Claude Code CLI
+ARG CLAUDE_CODE_VERSION=latest
+WORKDIR /tmp
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+# Container environment
+ENV DISABLE_AUTOUPDATER=1
+ENV DEVCONTAINER=true
+
+# Non-root user (node user ships with node:20 image)
+RUN echo "node ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/node
+
+# Firewall init script
+COPY init-firewall.sh /usr/local/bin/init-firewall.sh
+RUN chmod +x /usr/local/bin/init-firewall.sh
+
+# direnv hook
+RUN echo 'eval "$(direnv hook bash)"' >> /home/node/.bashrc
+
+USER node
+WORKDIR /workspace
+
+# Default: launch Claude interactively with permissions skipped.
+# Override with: docker run -it <image> bash
+CMD ["claude", "--dangerously-skip-permissions"]

--- a/Dockerfile.claude-code
+++ b/Dockerfile.claude-code
@@ -50,9 +50,26 @@ RUN chmod +x /usr/local/bin/init-firewall.sh
 # direnv hook
 RUN echo 'eval "$(direnv hook bash)"' >> /home/node/.bashrc
 
+# Claude settings mount points:
+#   ~/.claude/       → settings.json, CLAUDE.md, agents/, rules/, auto-memory
+#   ~/.claude.json   → auth token, MCP server configs
+# Pre-create so Docker bind-mounts don't create them as root-owned
+RUN mkdir -p /home/node/.claude \
+    && touch  /home/node/.claude.json \
+    && chown -R node:node /home/node/.claude /home/node/.claude.json
+VOLUME ["/home/node/.claude", "/home/node/.claude.json"]
+
 USER node
 WORKDIR /workspace
 
 # Default: launch Claude interactively with permissions skipped.
 # Override with: docker run -it <image> bash
+#
+# Mount host settings:
+#   docker run -it \
+#     -v ~/.claude:/home/node/.claude \
+#     -v ~/.claude.json:/home/node/.claude.json \
+#     -v "$(pwd):/workspace" \
+#     --cap-add NET_ADMIN \
+#     claude-code
 CMD ["claude", "--dangerously-skip-permissions"]

--- a/init-firewall.sh
+++ b/init-firewall.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Initialise an allowlist-only outbound firewall.
+# Run with: sudo /usr/local/bin/init-firewall.sh
+#
+# Allowed destinations:
+#   - DNS (UDP 53)
+#   - SSH (TCP 22)
+#   - Localhost / Docker host network
+#   - api.anthropic.com
+#   - GitHub (fetched from api.github.com/meta)
+#   - npm registry (registry.npmjs.org)
+#   - Sentry & Statsig telemetry
+#
+set -euo pipefail
+
+# ── Create ipset for allowed IPs ────────────────────────────────────
+ipset create allowed_ips hash:net -exist
+ipset flush allowed_ips
+
+# Localhost
+ipset add allowed_ips 127.0.0.0/8
+ipset add allowed_ips ::1/128
+
+# Docker default bridge
+ipset add allowed_ips 172.17.0.0/16
+
+# Resolve and add IPs for a given hostname
+add_host() {
+  local host="$1"
+  for ip in $(dig +short "$host" A 2>/dev/null || true); do
+    [[ "$ip" =~ ^[0-9]+\. ]] && ipset add allowed_ips "$ip/32" -exist
+  done
+  for ip in $(dig +short "$host" AAAA 2>/dev/null || true); do
+    [[ "$ip" =~ : ]] && ipset add allowed_ips "$ip/128" -exist
+  done
+}
+
+# Anthropic API
+add_host api.anthropic.com
+
+# npm registry
+add_host registry.npmjs.org
+
+# Sentry & Statsig (telemetry)
+add_host sentry.io
+add_host statsig.anthropic.com
+add_host statsig.com
+
+# GitHub IPs (from their meta endpoint)
+if command -v curl &>/dev/null && command -v jq &>/dev/null; then
+  gh_meta=$(curl -fsSL https://api.github.com/meta 2>/dev/null || echo '{}')
+  for cidr in $(echo "$gh_meta" | jq -r '(.web // [])[] , (.api // [])[] , (.git // [])[] , (.actions // [])[]' 2>/dev/null | sort -u); do
+    ipset add allowed_ips "$cidr" -exist 2>/dev/null || true
+  done
+fi
+
+# ── iptables rules ──────────────────────────────────────────────────
+
+# Allow all loopback
+iptables  -A OUTPUT -o lo -j ACCEPT
+ip6tables -A OUTPUT -o lo -j ACCEPT
+
+# Allow established/related (so replies to our allowed requests come back)
+iptables  -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow DNS
+iptables  -A OUTPUT -p udp --dport 53 -j ACCEPT
+ip6tables -A OUTPUT -p udp --dport 53 -j ACCEPT
+
+# Allow SSH
+iptables  -A OUTPUT -p tcp --dport 22 -j ACCEPT
+ip6tables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+
+# Allow traffic to our allowlisted IPs (HTTP/HTTPS)
+iptables  -A OUTPUT -p tcp --dport 80  -m set --match-set allowed_ips dst -j ACCEPT
+iptables  -A OUTPUT -p tcp --dport 443 -m set --match-set allowed_ips dst -j ACCEPT
+ip6tables -A OUTPUT -p tcp --dport 80  -m set --match-set allowed_ips dst -j ACCEPT
+ip6tables -A OUTPUT -p tcp --dport 443 -m set --match-set allowed_ips dst -j ACCEPT
+
+# Drop everything else outbound
+iptables  -A OUTPUT -j DROP
+ip6tables -A OUTPUT -j DROP
+
+echo "Firewall initialised — outbound traffic restricted to allowlist."


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.claude-code` for running Claude Code interactively inside a container with `--dangerously-skip-permissions`
- Adds `init-firewall.sh` — an allowlist-only outbound firewall (iptables/ipset) that restricts network access to Anthropic API, GitHub, npm, and telemetry endpoints
- Container includes project tooling (bazelisk, direnv, gh) and runs as non-root `node` user

## Usage

```bash
# Build
docker build -f Dockerfile.claude-code -t claude-code .

# Run Claude interactively
docker run -it -e ANTHROPIC_API_KEY="sk-ant-..." -v "$(pwd):/workspace" --cap-add NET_ADMIN claude-code

# Drop to shell
docker run -it -e ANTHROPIC_API_KEY="sk-ant-..." -v "$(pwd):/workspace" --cap-add NET_ADMIN claude-code bash

# Initialize firewall (inside container)
sudo /usr/local/bin/init-firewall.sh
```

## Test plan

- [ ] `docker build -f Dockerfile.claude-code -t claude-code .` succeeds
- [ ] `docker run -it -e ANTHROPIC_API_KEY=... claude-code` launches Claude interactively
- [ ] `docker run -it claude-code bash` drops to a shell with `claude`, `bazel`, `git`, `gh` on PATH
- [ ] `sudo /usr/local/bin/init-firewall.sh` initializes firewall without errors
- [ ] Outbound traffic to non-allowlisted hosts is blocked after firewall init