### PR TITLE
fix: enable SQLite foreign key enforcement per connection

### DIFF
--- a/server/db/src/lib.rs
+++ b/server/db/src/lib.rs
@@ -1,10 +1,14 @@
-use sqlx::{Row, SqlitePool, sqlite::SqlitePoolOptions, sqlite::SqliteRow};
+use sqlx::{
+    Row, SqlitePool, sqlite::SqliteConnectOptions, sqlite::SqlitePoolOptions, sqlite::SqliteRow,
+};
+use std::str::FromStr;
 use uuid::Uuid;
 
 pub async fn connect(url: &str) -> Result<SqlitePool, sqlx::Error> {
+    let options = SqliteConnectOptions::from_str(url)?.pragma("foreign_keys", "ON");
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
-        .connect(url)
+        .connect_with(options)
         .await?;
 
     migrations::MIGRATOR


### PR DESCRIPTION
## Summary
- Parse the connection URL into `SqliteConnectOptions` and set `.pragma("foreign_keys", "ON")` so every pooled connection enforces referential integrity
- Uses `connect_with(options)` instead of `connect(url)` to pass the configured options to the pool

Closes #26

## Test plan
- [x] `aspect build //server/...` passes
- [x] `aspect test //server/...` passes
- [x] `bazel run //tools/format` produces no additional changes