### PR TITLE
chore: add worktree directories to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,5 @@
 gradle/
 target/
 .opencode/
+.claude/worktrees/
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` and `.worktrees/` to `.bazelignore` to prevent Bazel from analyzing files in git worktree directories used for isolated development

## Test plan
- [x] Verify `aspect build //...` succeeds without picking up worktree contents