### PR TITLE
refactor: encapsulate db row types behind domain-oriented API

### DIFF
--- a/build-scan/server/db/src/lib.rs
+++ b/build-scan/server/db/src/lib.rs
@@ -19,37 +19,35 @@ pub async fn connect(url: &str) -> Result<SqlitePool> {
 }
 
 #[derive(Debug, sqlx::FromRow)]
-pub struct BuildScanRow {
-    pub id: String,
-    pub build_tool_type: String,
-    pub build_tool_version: String,
-    pub plugin_version: String,
-    pub started_at: Option<String>,
-    pub finished_at: Option<String>,
-    pub outcome: Option<String>,
-    pub requested_tasks: Option<String>,
-    pub hostname: Option<String>,
-    pub os_name: Option<String>,
-    pub os_version: Option<String>,
-    pub jvm_vendor: Option<String>,
-    pub jvm_version: Option<String>,
-    #[sqlx(default)]
-    pub raw_payload: Option<Vec<u8>>,
-    pub created_at: String,
+struct BuildScanRow {
+    id: String,
+    build_tool_type: String,
+    build_tool_version: String,
+    plugin_version: String,
+    started_at: Option<String>,
+    finished_at: Option<String>,
+    outcome: Option<String>,
+    requested_tasks: Option<String>,
+    hostname: Option<String>,
+    os_name: Option<String>,
+    os_version: Option<String>,
+    jvm_vendor: Option<String>,
+    jvm_version: Option<String>,
+    created_at: String,
 }
 
 #[derive(Debug, sqlx::FromRow)]
-pub struct TaskRow {
-    pub id: String,
-    pub scan_id: String,
-    pub task_path: String,
-    pub class_name: Option<String>,
-    pub outcome: Option<String>,
-    pub cacheable: Option<bool>,
-    pub start_timestamp: Option<i64>,
-    pub finish_timestamp: Option<i64>,
-    pub cache_key: Option<String>,
-    pub origin_execution_time: Option<i64>,
+struct TaskRow {
+    id: String,
+    scan_id: String,
+    task_path: String,
+    class_name: Option<String>,
+    outcome: Option<String>,
+    cacheable: Option<bool>,
+    start_timestamp: Option<i64>,
+    finish_timestamp: Option<i64>,
+    cache_key: Option<String>,
+    origin_execution_time: Option<i64>,
 }
 
 fn parse_datetime(s: &str) -> Result<chrono::DateTime<Utc>> {
@@ -165,7 +163,6 @@ impl From<&domain::BuildScan> for BuildScanRow {
             os_version: scan.os_version.as_ref().map(|v| v.0.clone()),
             jvm_vendor: scan.jvm_vendor.as_ref().map(|v| v.0.clone()),
             jvm_version: scan.jvm_version.as_ref().map(|v| v.0.clone()),
-            raw_payload: None,
             created_at: scan.created_at.format("%Y-%m-%d %H:%M:%S").to_string(),
         }
     }
@@ -190,8 +187,11 @@ impl From<&domain::Task> for TaskRow {
 
 pub async fn insert_build_scan<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite>>(
     executor: E,
-    row: &BuildScanRow,
+    scan: &domain::BuildScan,
+    raw_payload: Option<&[u8]>,
 ) -> Result<()> {
+    let row = BuildScanRow::from(scan);
+
     sqlx::query(
         "INSERT INTO build_scans (id, build_tool_type, build_tool_version, plugin_version, started_at, finished_at, outcome, requested_tasks, hostname, os_name, os_version, jvm_vendor, jvm_version, raw_payload, created_at) \
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -209,7 +209,7 @@ pub async fn insert_build_scan<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite
     .bind(row.os_version.as_deref())
     .bind(row.jvm_vendor.as_deref())
     .bind(row.jvm_version.as_deref())
-    .bind(row.raw_payload.as_deref())
+    .bind(raw_payload)
     .bind(&row.created_at)
     .execute(executor)
     .await?;
@@ -219,8 +219,9 @@ pub async fn insert_build_scan<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite
 
 pub async fn insert_task<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite>>(
     executor: E,
-    row: &TaskRow,
+    task: &domain::Task,
 ) -> Result<()> {
+    let row = TaskRow::from(task);
     let cacheable_int: Option<i64> = row.cacheable.map(|b| if b { 1 } else { 0 });
 
     sqlx::query(
@@ -248,7 +249,7 @@ pub async fn list_build_scans(
     limit: i64,
     after_created_at: Option<&str>,
     after_id: Option<&str>,
-) -> Result<Vec<BuildScanRow>> {
+) -> Result<Vec<domain::BuildScan>> {
     let rows = match (after_created_at, after_id) {
         (Some(cursor_created_at), Some(cursor_id)) => {
             sqlx::query_as::<_, BuildScanRow>(
@@ -272,10 +273,12 @@ pub async fn list_build_scans(
         }
     };
 
-    Ok(rows)
+    rows.into_iter()
+        .map(domain::BuildScan::try_from)
+        .collect::<Result<Vec<_>>>()
 }
 
-pub async fn get_build_scan(pool: &SqlitePool, id: &str) -> Result<Option<BuildScanRow>> {
+pub async fn get_build_scan(pool: &SqlitePool, id: &str) -> Result<Option<domain::BuildScan>> {
     let row = sqlx::query_as::<_, BuildScanRow>(
         "SELECT id, build_tool_type, build_tool_version, plugin_version, started_at, finished_at, outcome, requested_tasks, hostname, os_name, os_version, jvm_vendor, jvm_version, created_at \
          FROM build_scans WHERE id = ?",
@@ -284,7 +287,7 @@ pub async fn get_build_scan(pool: &SqlitePool, id: &str) -> Result<Option<BuildS
     .fetch_optional(pool)
     .await?;
 
-    Ok(row)
+    row.map(domain::BuildScan::try_from).transpose()
 }
 
 pub async fn list_tasks(
@@ -292,7 +295,7 @@ pub async fn list_tasks(
     scan_id: &str,
     limit: i64,
     after_id: Option<&str>,
-) -> Result<Vec<TaskRow>> {
+) -> Result<Vec<domain::Task>> {
     let rows = if let Some(cursor) = after_id {
         sqlx::query_as::<_, TaskRow>(
             "SELECT id, scan_id, task_path, class_name, outcome, cacheable, start_timestamp, finish_timestamp, cache_key, origin_execution_time \
@@ -314,7 +317,9 @@ pub async fn list_tasks(
         .await?
     };
 
-    Ok(rows)
+    rows.into_iter()
+        .map(domain::Task::try_from)
+        .collect::<Result<Vec<_>>>()
 }
 
 pub async fn count_tasks(pool: &SqlitePool, scan_id: &str) -> Result<i64> {
@@ -334,7 +339,7 @@ pub async fn count_build_scans(pool: &SqlitePool) -> Result<i64> {
     Ok(count)
 }
 
-pub async fn get_task(pool: &SqlitePool, id: &str) -> Result<Option<TaskRow>> {
+pub async fn get_task(pool: &SqlitePool, id: &str) -> Result<Option<domain::Task>> {
     let row = sqlx::query_as::<_, TaskRow>(
         "SELECT id, scan_id, task_path, class_name, outcome, cacheable, start_timestamp, finish_timestamp, cache_key, origin_execution_time \
          FROM tasks WHERE id = ?",
@@ -343,5 +348,5 @@ pub async fn get_task(pool: &SqlitePool, id: &str) -> Result<Option<TaskRow>> {
     .fetch_optional(pool)
     .await?;
 
-    Ok(row)
+    row.map(domain::Task::try_from).transpose()
 }

--- a/build-scan/server/service/src/lib.rs
+++ b/build-scan/server/service/src/lib.rs
@@ -57,9 +57,7 @@ impl BuildScanService {
                     .build()
                     .map_err(|e| anyhow::anyhow!(e))
                     .context("failed to build parse-error BuildScan")?;
-                let mut row = db::BuildScanRow::from(&scan);
-                row.raw_payload = Some(req.raw_payload.clone());
-                db::insert_build_scan(&self.pool, &row)
+                db::insert_build_scan(&self.pool, &scan, Some(&req.raw_payload))
                     .await
                     .context("failed to store parse_error scan")?;
             }
@@ -119,9 +117,7 @@ impl BuildScanService {
                     .await
                     .context("failed to begin transaction")?;
 
-                let mut row = db::BuildScanRow::from(&scan);
-                row.raw_payload = Some(req.raw_payload.clone());
-                db::insert_build_scan(&mut *tx, &row)
+                db::insert_build_scan(&mut *tx, &scan, Some(&req.raw_payload))
                     .await
                     .context("failed to store build scan")?;
 
@@ -165,8 +161,7 @@ impl BuildScanService {
                         .map_err(|e| anyhow::anyhow!(e))
                         .context("failed to build Task")?;
 
-                    let task_row = db::TaskRow::from(&domain_task);
-                    db::insert_task(&mut *tx, &task_row)
+                    db::insert_task(&mut *tx, &domain_task)
                         .await
                         .with_context(|| format!("failed to store task {}", task.task_path))?;
                 }
@@ -181,8 +176,7 @@ impl BuildScanService {
     }
 
     pub async fn get_build_scan(&self, id: &str) -> Result<Option<domain::BuildScan>> {
-        let row = db::get_build_scan(&self.pool, id).await?;
-        Ok(row.map(domain::BuildScan::try_from).transpose()?)
+        db::get_build_scan(&self.pool, id).await
     }
 
     pub async fn list_build_scans(
@@ -191,16 +185,11 @@ impl BuildScanService {
         after_created_at: Option<&str>,
         after_id: Option<&str>,
     ) -> Result<Vec<domain::BuildScan>> {
-        let rows = db::list_build_scans(&self.pool, limit, after_created_at, after_id).await?;
-        Ok(rows
-            .into_iter()
-            .map(domain::BuildScan::try_from)
-            .collect::<Result<Vec<_>, _>>()?)
+        db::list_build_scans(&self.pool, limit, after_created_at, after_id).await
     }
 
     pub async fn get_task(&self, id: &str) -> Result<Option<domain::Task>> {
-        let row = db::get_task(&self.pool, id).await?;
-        Ok(row.map(domain::Task::try_from).transpose()?)
+        db::get_task(&self.pool, id).await
     }
 
     pub async fn list_tasks(
@@ -209,18 +198,14 @@ impl BuildScanService {
         limit: i64,
         after_id: Option<&str>,
     ) -> Result<Vec<domain::Task>> {
-        let rows = db::list_tasks(&self.pool, scan_id, limit, after_id).await?;
-        Ok(rows
-            .into_iter()
-            .map(domain::Task::try_from)
-            .collect::<Result<Vec<_>, _>>()?)
+        db::list_tasks(&self.pool, scan_id, limit, after_id).await
     }
 
     pub async fn count_tasks(&self, scan_id: &str) -> Result<i64> {
-        Ok(db::count_tasks(&self.pool, scan_id).await?)
+        db::count_tasks(&self.pool, scan_id).await
     }
 
     pub async fn count_build_scans(&self) -> Result<i64> {
-        Ok(db::count_build_scans(&self.pool).await?)
+        db::count_build_scans(&self.pool).await
     }
 }


### PR DESCRIPTION
## Summary
- Make `BuildScanRow` and `TaskRow` private to the db crate — they are storage implementation details, not part of the public API
- All public db functions (`insert_build_scan`, `insert_task`, `get_build_scan`, `list_build_scans`, `get_task`, `list_tasks`) now accept and return domain objects directly
- `insert_build_scan` takes a separate `raw_payload: Option<&[u8]>` parameter since raw payload is a storage concern not present in the domain model
- Service layer simplified: query methods become direct pass-throughs, write methods no longer manually convert to/from row types

## Test plan
- [x] All 12 tests pass (`aspect test //...`)
- [x] Zero compiler warnings
- [x] `bazel run //tools/format` produces no changes