### PR TITLE
fix: use Kryo-long encoding for TestExecutorIdentity fields

### DIFF
--- a/build-scan/lib/src/events/test_executor_identity.rs
+++ b/build-scan/lib/src/events/test_executor_identity.rs
@@ -12,13 +12,13 @@ impl BodyDecoder for TestExecutorIdentityDecoder {
         let mut table = kryo::StringInternTable::new();
 
         let executor_id = if kryo::is_field_present(flags as u16, 0) {
-            ExecutorId::new(kryo::read_task_id(body, &mut pos)?)
+            ExecutorId::new(kryo::read_kryo_long(body, &mut pos)?)
         } else {
             ExecutorId::new(0)
         };
         // Bit 1: hash — read and discard
         if kryo::is_field_present(flags as u16, 1) {
-            let _ = kryo::read_task_id(body, &mut pos)?;
+            let _ = kryo::read_kryo_long(body, &mut pos)?;
         }
         let name = if kryo::is_field_present(flags as u16, 2) {
             table.read_string(body, &mut pos)?
@@ -41,7 +41,7 @@ mod tests {
         // Flags are inverted: bit=0 means field IS present.
         // executor_id (bit 0)=0, hash (bit 1)=1 (absent/skip), name (bit 2)=0 → flags = 0x02
         let mut data = vec![0x02];
-        data.extend_from_slice(&99i64.to_le_bytes()); // executor_id
+        data.extend_from_slice(&kryo::encode_kryo_long(99)); // executor_id as Kryo-long
         // name "Gradle Test Executor 1" → len=22, zigzag(22)=44=0x2C
         let name = "Gradle Test Executor 1";
         let zigzag_len = (name.len() as u64) * 2;


### PR DESCRIPTION
## Summary
- Changed `read_task_id` → `read_kryo_long` for both `executor_id` and `hash` fields in the TestExecutorIdentity decoder (wire 127)
- Updated unit test to use `encode_kryo_long()` for test data encoding
- Same fix pattern as #53 (TestResult executor_id mismatch)

The encoding mismatch caused the `executor_names` HashMap lookup in `assembly.rs` to fail silently — wire 127 decoded a different i64 value than wire 798 for the same logical executor ID, so the `.get()` never matched.

Fixes #54

## Test plan
- [x] New Kryo-long encoding test written (TDD red-green verified)
- [x] Existing test updated to use correct encoding
- [x] Full test suite passes (12/12 targets)