### PR TITLE
ci: publish Docker image to GHCR on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: bazel-contrib/setup-bazel@30962902d2fd41169beb19c051e47c540c7d052a
         with:
           bazelisk-cache: true


### PR DESCRIPTION
## Summary
- Adds a `deploy.yml` workflow that triggers after the "Tests" workflow succeeds on `main`
- Logs into GHCR using the built-in `GITHUB_TOKEN`
- Dynamically discovers and pushes all `oci_push` targets with `--compilation_mode=opt`

Mirrors the deploy workflow from `bazel-repo`.

## Test plan
- [ ] Merge to main and verify the deploy workflow triggers after Tests passes
- [ ] Confirm image is published to `ghcr.io/lowkeylab/build-scan-server`