### PR TITLE
fix: use relative URL for GraphQL endpoint

### DIFF
--- a/angular/projects/build-scan-web/src/app/graphql.provider.ts
+++ b/angular/projects/build-scan-web/src/app/graphql.provider.ts
@@ -3,7 +3,7 @@ import { provideApollo } from 'apollo-angular';
 import { HttpLink } from 'apollo-angular/http';
 import { InMemoryCache } from '@apollo/client/core';
 
-const GRAPHQL_URI = 'http://localhost:3000/graphql';
+const GRAPHQL_URI = '/graphql';
 
 export function provideGraphql() {
   return provideApollo(() => {


### PR DESCRIPTION
## Summary
- Replace hardcoded `http://localhost:3000/graphql` with relative `/graphql` in `graphql.provider.ts`
- Fixes deployment behind different hosts/ports or reverse proxies

Closes #34

## Test plan
- [x] `aspect build //...` passes
- [x] `aspect test //...` passes (all 12 tests)
- [x] No other hardcoded `localhost:3000` references in non-test source files