### PR TITLE
fix: use relative URL for GraphQL endpoint

### DIFF
--- a/angular/projects/build-scan-web/src/app/graphql.provider.ts
+++ b/angular/projects/build-scan-web/src/app/graphql.provider.ts
@@ -3,7 +3,7 @@ import { provideApollo } from 'apollo-angular';
 import { HttpLink } from 'apollo-angular/http';
 import { InMemoryCache } from '@apollo/client/core';
 
-const GRAPHQL_URI = '/graphql';
+const GRAPHQL_URI = new URL('graphql', document.baseURI).toString();
 
 export function provideGraphql() {
   return provideApollo(() => {


### PR DESCRIPTION
## Summary
- Replace hardcoded `http://localhost:3000/graphql` with relative `/graphql` in `graphql.provider.ts`
- Fixes deployment behind different hosts/ports or reverse proxies

Closes #34

## Test plan
- [x] `aspect build //...` passes
- [x] `aspect test //...` passes