### PR TITLE
docs: add CLAUDE.md files for subprojects

### DIFF
--- a/angular/CLAUDE.md
+++ b/angular/CLAUDE.md
@@ -1,0 +1,58 @@
+# Angular Frontend
+
+Angular 21 SPA for browsing Gradle build scans. Communicates exclusively via GraphQL with the Rust backend.
+
+## Targets
+
+### Build
+
+```bash
+aspect build //angular/projects/build-scan-web   # Build production app
+```
+
+### Test
+
+```bash
+aspect test //angular/projects/build-scan-web:test   # Run Vitest unit tests
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Angular 21 (standalone components, zoneless change detection) |
+| State | Apollo Client (GraphQL-centric, no NgRx) |
+| Styling | Tailwind CSS + DaisyUI |
+| Testing | Vitest |
+| Build | Bazel via custom `ng_application` / `ng_test` macros in `bzl/ng.bzl` |
+
+## Project Structure
+
+```
+angular/
+├── bzl/ng.bzl                           # Bazel macros (ng_application, ng_test, process_styles)
+└── projects/build-scan-web/src/app/
+    ├── app.ts                           # Root component (RouterOutlet)
+    ├── app.routes.ts                    # Route definitions
+    ├── app.config.ts                    # Providers (zoneless, router, http, graphql)
+    ├── graphql.provider.ts              # Apollo Client setup (URI from document.baseURI)
+    └── scans/
+        ├── scan-list.component.ts       # /scans — paginated scan list
+        └── scan-detail.component.ts     # /scans/:id — scan metadata, tasks, tests
+```
+
+## Routes
+
+| Route | Component | Description |
+|-------|-----------|-------------|
+| `/scans` | ScanListComponent | Paginated list of build scans (20/page) |
+| `/scans/:id` | ScanDetailComponent | Scan details with tasks and tests tables |
+
+## GraphQL Queries
+
+- `GetBuildScans(first, after)` — Relay cursor pagination for scan list
+- `GetBuildScan(id, firstTasks, afterTasks, firstTests, afterTests)` — Single scan with nested task/test connections
+
+## Backend Integration
+
+The app is served by the Rust server at `/web/*` when `SPA_DIR` is configured. The GraphQL endpoint is resolved relative to `document.baseURI` as `/graphql`.

--- a/build-scan/CLAUDE.md
+++ b/build-scan/CLAUDE.md
@@ -1,0 +1,45 @@
+# Build Scan
+
+Core parsing library and CLI for decoding Gradle build scan binary payloads.
+
+## Modules
+
+### Library (`lib/`)
+
+Decodes the Gradle build scan wire format: outer header → gzip decompression → delta-encoded event frames → Kryo body decoding → structured `BuildScanPayload`.
+
+```bash
+aspect test //build-scan/lib/...   # Run library tests
+```
+
+#### Parsing Pipeline
+
+```
+Raw Bytes → OuterHeader → Gzip → Framing (wire_id + body) → Event Decoding → Assembly → BuildScanPayload
+```
+
+#### Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `lib.rs` | Entry point: `parse(raw_bytes) → BuildScanPayload` |
+| `outer_header.rs` | Parses outer header, finds gzip offset |
+| `decompress.rs` | Gzip decompression |
+| `framing.rs` | Reads delta-encoded event frames |
+| `varint.rs` | LEB128 varint + ZigZag encoding |
+| `kryo.rs` | Kryo serialization helpers (per-event string interning) |
+| `events/mod.rs` | DecoderRegistry — 40+ wire_id → BodyDecoder mappings |
+| `assembly.rs` | Maps decoded events into `BuildScanPayload` |
+| `models.rs` | Data structures (Task, TestCase, TaskOutcome, etc.) |
+
+### CLI (`cli/`)
+
+Standalone tool that reads an echo-server JSON payload file, decodes the base64 build scan body, and prints parsed JSON.
+
+```bash
+bazel run //build-scan/cli/src:main -- /path/to/payload.json
+```
+
+### Server (`server/`)
+
+See [`server/CLAUDE.md`](server/CLAUDE.md) for the HTTP server, database, GraphQL API, and ingest protocol.

--- a/gradle/CLAUDE.md
+++ b/gradle/CLAUDE.md
@@ -1,0 +1,38 @@
+# Gradle Test Project
+
+Standalone Gradle/Kotlin multi-module project used for **dogfooding** — it publishes build scans to the build scan server, generating real traffic for testing and development.
+
+This is NOT part of the build scan server itself. It exists to produce Gradle build events that the server can ingest.
+
+## Targets
+
+### Build & Test
+
+```bash
+cd gradle && ./gradlew build   # Build all modules and run tests
+cd gradle && ./gradlew :app:run   # Run the CLI app
+```
+
+### Publishing Build Scans
+
+Set `DEVELOCITY_SERVER_URL` to point at your local build scan server:
+
+```bash
+DEVELOCITY_SERVER_URL=http://localhost:3000 ./gradlew build
+```
+
+## Module Structure
+
+| Module | Type | Purpose |
+|--------|------|---------|
+| `app/` | Application | CLI entry point — splits, joins, and capitalizes strings |
+| `utilities/` | Library | String utility facades (split/join via LinkedList) |
+| `list/` | Library | Custom doubly-linked list implementation |
+| `build-logic/` | Convention plugins | Shared build configuration (Kotlin JVM, Java 21 toolchain, JUnit 5) |
+
+## Build Configuration
+
+- **Gradle** with Kotlin DSL and convention plugins
+- **Develocity plugin** v4.3.2 configured in `settings.gradle.kts`
+- **Configuration cache**, parallel execution, and local caching enabled via `gradle.properties`
+- **Java 21** toolchain

--- a/proxy/CLAUDE.md
+++ b/proxy/CLAUDE.md
@@ -1,0 +1,54 @@
+# Proxy
+
+HTTP intercepting proxy that sits between Gradle clients and an upstream build scan server. Captures all request/response traffic to a local SQLite database and exposes it via a GraphQL API.
+
+## Targets
+
+### Run (development)
+
+```bash
+ibazel run //proxy/src:main   # Hot-reload
+bazel run //proxy/src:main    # Single run
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8080` | Server listen port |
+| `UPSTREAM_URL` | *(required)* | Upstream build scan server URL |
+| `DATABASE_URL` | `sqlite:proxy.db` | SQLite connection string |
+
+## Crate Layout
+
+| Crate | Path | Purpose |
+|-------|------|---------|
+| `main` | `src/` | Axum router, proxy handler, server entrypoint |
+| `config` | `config/src/` | Env-based configuration |
+| `db` | `db/src/` | SQLite pool + CRUD queries (sqlx) |
+| `domain` | `domain/src/` | Domain models (Payload, RequestData, ResponseData) |
+| `format` | `format/src/` | Wire format types for JSON serialization |
+| `service` | `service/src/` | Business logic — transforms format types to domain |
+| `graphql` | `graphql/src/` | Juniper schema + resolvers |
+| `relay` | `graphql/relay/src/` | Relay Global Object ID + cursor pagination |
+
+## Data Flow
+
+```
+Client Request
+  → proxy_handler captures method/uri/headers/body
+  → forwards to UPSTREAM_URL via reqwest
+  → captures response status/headers/body
+  → ProxyService::store_payload() → SQLite INSERT
+  → returns upstream response to client
+```
+
+## GraphQL API
+
+- `node(id: ID!): Node` — Relay global ID resolution
+- `payload(id: ID!): Payload` — Direct UUID or Relay ID lookup
+- `payloads(first: Int, after: String): PayloadConnection!` — Cursor pagination
+
+## Database Schema
+
+Single `payloads` table with columns: id (UUID), request_id, timestamp, method, uri, request_headers (JSON), request_body, response_status, response_headers (JSON), response_body, response_error, created_at.


### PR DESCRIPTION
## Summary
- Add `angular/CLAUDE.md` — Angular 21 SPA tech stack, routes, GraphQL queries, backend integration
- Add `build-scan/CLAUDE.md` — parsing library wire format pipeline, CLI usage, links to server CLAUDE.md
- Add `gradle/CLAUDE.md` — dogfooding test project, module structure, Develocity integration
- Add `proxy/CLAUDE.md` — HTTP intercepting proxy crate layout, env vars, data flow, GraphQL API

## Test plan
- [x] Verify each CLAUDE.md is picked up by Claude Code when working in the respective subproject
- [x] Confirm no build targets are affected (`aspect build //...`)