### PR TITLE
feat: add task execution timeline to build scan detail

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
@@ -334,7 +334,7 @@ describe('ScanDetailComponent', () => {
       tasks: {
         edges: [
           buildTaskEdge({ id: 'T1', taskPath: ':compileJava', startTimestamp: 1000, finishTimestamp: 1120 }),
-          buildTaskEdge({ id: 'T2', taskPath: ':processResources', startTimestamp: 1050, finishTimestamp: 1080, cursor: 'c2' }),
+          buildTaskEdge({ id: 'T2', taskPath: ':processResources', startTimestamp: 1050, finishTimestamp: 1080 }),
         ],
         pageInfo: { hasNextPage: false, endCursor: null },
       },

--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -131,11 +131,11 @@ const GET_BUILD_SCAN = gql`
           Tasks ({{ scan.taskCount }})
         </h3>
 
-        @if (getTimelineTasks(scan.tasks.edges).length > 0) {
+        @if (getTimeline(scan.tasks.edges); as timeline) {
           <div class="card bg-base-200 mb-6">
             <div class="card-body p-4">
               <h4 class="font-semibold mb-2">Timeline</h4>
-              @for (item of getTimelineData(scan.tasks.edges); track item.id) {
+              @for (item of timeline.items; track item.id) {
                 <div class="flex items-center gap-2 py-0.5">
                   <span class="font-mono text-xs w-48 truncate text-right shrink-0" [title]="item.taskPath">{{ item.taskPath }}</span>
                   <div class="relative flex-1 h-5">
@@ -158,9 +158,9 @@ const GET_BUILD_SCAN = gql`
                 <span class="w-48 shrink-0"></span>
                 <div class="relative flex-1 flex justify-between text-xs opacity-50">
                   <span>0ms</span>
-                  @if (getTimelineDuration(scan.tasks.edges) > 0) {
-                    <span>{{ formatDuration(getTimelineDuration(scan.tasks.edges) / 2) }}</span>
-                    <span>{{ formatDuration(getTimelineDuration(scan.tasks.edges)) }}</span>
+                  @if (timeline.duration > 0) {
+                    <span>{{ formatDuration(timeline.duration / 2) }}</span>
+                    <span>{{ formatDuration(timeline.duration) }}</span>
                   }
                 </div>
               </div>
@@ -272,46 +272,51 @@ export class ScanDetailComponent {
     map(result => result.data.buildScan)
   );
 
-  getTimelineTasks(edges: any[]): any[] {
-    return edges.filter(
+  getTimeline(edges: any[]): { items: any[]; duration: number } | null {
+    const tasks = edges.filter(
       (e: any) => e.node.startTimestamp != null && e.node.finishTimestamp != null
     );
-  }
+    if (tasks.length === 0) return null;
 
-  getTimelineDuration(edges: any[]): number {
-    const tasks = this.getTimelineTasks(edges);
-    if (tasks.length === 0) return 0;
-    const minStart = Math.min(...tasks.map((e: any) => e.node.startTimestamp));
-    const maxFinish = Math.max(...tasks.map((e: any) => e.node.finishTimestamp));
-    return maxFinish - minStart;
-  }
+    let minStart = Infinity;
+    let maxFinish = -Infinity;
+    for (const e of tasks) {
+      if (e.node.startTimestamp < minStart) minStart = e.node.startTimestamp;
+      if (e.node.finishTimestamp > maxFinish) maxFinish = e.node.finishTimestamp;
+    }
+    const duration = maxFinish - minStart;
 
-  getTimelineData(edges: any[]): any[] {
-    const tasks = this.getTimelineTasks(edges);
-    if (tasks.length === 0) return [];
-    const minStart = Math.min(...tasks.map((e: any) => e.node.startTimestamp));
-    const totalDuration = this.getTimelineDuration(edges);
-    if (totalDuration === 0) return tasks.map((e: any) => ({
-      id: e.node.id,
-      taskPath: e.node.taskPath,
-      outcome: e.node.outcome,
-      durationMs: e.node.durationMs,
-      leftPct: 0,
-      widthPct: 100,
-    }));
-    return tasks.map((e: any) => {
-      const start = e.node.startTimestamp - minStart;
-      const duration = e.node.finishTimestamp - e.node.startTimestamp;
-      const widthPct = Math.max((duration / totalDuration) * 100, 0.5);
+    if (duration === 0) {
       return {
-        id: e.node.id,
-        taskPath: e.node.taskPath,
-        outcome: e.node.outcome,
-        durationMs: e.node.durationMs,
-        leftPct: (start / totalDuration) * 100,
-        widthPct,
+        duration: 0,
+        items: tasks.map((e: any) => ({
+          id: e.node.id,
+          taskPath: e.node.taskPath,
+          outcome: e.node.outcome,
+          durationMs: 0,
+          leftPct: 0,
+          widthPct: 100,
+        })),
       };
-    });
+    }
+
+    return {
+      duration,
+      items: tasks.map((e: any) => {
+        const start = e.node.startTimestamp - minStart;
+        const taskDuration = Math.max(e.node.finishTimestamp - e.node.startTimestamp, 0);
+        const leftPct = (start / duration) * 100;
+        const widthPct = Math.min(Math.max((taskDuration / duration) * 100, 0.5), 100 - leftPct);
+        return {
+          id: e.node.id,
+          taskPath: e.node.taskPath,
+          outcome: e.node.outcome,
+          durationMs: taskDuration,
+          leftPct,
+          widthPct,
+        };
+      }),
+    };
   }
 
   formatDuration(ms: number): string {


### PR DESCRIPTION
## Summary
- Adds a Gantt-style timeline visualization above the tasks table in the build scan detail view
- Task bars are positioned by `startTimestamp`/`finishTimestamp` and color-coded by outcome (green=Success, blue=FromCache, red=Failed, yellow=Skipped)
- Shows parallelism at a glance with a time axis (0ms to total build duration)
- Pure CSS implementation using Tailwind/DaisyUI — no charting library needed

## Changes
- Extended GraphQL query to fetch `startTimestamp` and `finishTimestamp` fields (already exposed by backend)
- Added timeline rendering with tooltip hover showing task path and duration
- Added 3 new tests covering timeline rendering, color-coding, and null-timestamp filtering

## Test plan
- [x] All existing tests pass
- [x] New timeline tests pass (renders, color-codes, excludes null timestamps)
- [x] `aspect build //angular/projects/build-scan-web` succeeds
- [x] Manual verification with live build scan data