### PR TITLE
feat: display task execution timeline as worker swimlanes

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
@@ -328,7 +328,7 @@ describe('ScanDetailComponent', () => {
     expect(rows.length).toBe(2);
   });
 
-  it('should render timeline section when tasks have timestamps', () => {
+  it('should render timeline with worker lanes for overlapping tasks', () => {
     flushQuery({
       taskCount: 2,
       tasks: {
@@ -342,10 +342,37 @@ describe('ScanDetailComponent', () => {
     const timeline = fixture.nativeElement.querySelector('.card.bg-base-200');
     expect(timeline).toBeTruthy();
     const heading = timeline.querySelector('h4');
-    expect(heading.textContent.trim()).toBe('Timeline');
+    expect(heading.textContent).toContain('Timeline');
+    expect(heading.textContent).toContain('2 workers');
+    // Overlapping tasks should be in separate lanes
+    const workerLabels = timeline.querySelectorAll('.opacity-50');
+    // First two .opacity-50 spans are worker labels
+    expect(workerLabels[0].textContent.trim()).toBe('Worker 1');
+    expect(workerLabels[1].textContent.trim()).toBe('Worker 2');
+  });
+
+  it('should assign sequential tasks to the same lane', () => {
+    flushQuery({
+      taskCount: 2,
+      tasks: {
+        edges: [
+          buildTaskEdge({ id: 'T1', taskPath: ':a', startTimestamp: 0, finishTimestamp: 100 }),
+          buildTaskEdge({ id: 'T2', taskPath: ':b', startTimestamp: 100, finishTimestamp: 200 }),
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    const timeline = fixture.nativeElement.querySelector('.card.bg-base-200');
+    expect(timeline.textContent).toContain('1 worker');
+    // Both tasks in one lane = one row with relative positioning
+    const bars = timeline.querySelectorAll('.rounded-sm');
+    expect(bars.length).toBe(2);
   });
 
   it('should color-code timeline bars by outcome', () => {
+    // T1 and T2 overlap, so they go to separate lanes.
+    // T3 starts when T1 ends, so it joins lane 1.
+    // Lane 1: [T1(Success), T3(Failed)], Lane 2: [T2(FromCache)]
     flushQuery({
       taskCount: 3,
       tasks: {
@@ -358,10 +385,11 @@ describe('ScanDetailComponent', () => {
       },
     });
     const timeline = fixture.nativeElement.querySelector('.card.bg-base-200');
-    const bars = timeline.querySelectorAll('.rounded');
-    expect(bars[0].classList.contains('bg-success')).toBe(true);
-    expect(bars[1].classList.contains('bg-info')).toBe(true);
-    expect(bars[2].classList.contains('bg-error')).toBe(true);
+    const bars = timeline.querySelectorAll('.rounded-sm');
+    // DOM order: lane 1 bars first (T1, T3), then lane 2 (T2)
+    expect(bars[0].classList.contains('bg-success')).toBe(true);  // T1
+    expect(bars[1].classList.contains('bg-error')).toBe(true);    // T3
+    expect(bars[2].classList.contains('bg-info')).toBe(true);     // T2
   });
 
   it('should exclude tasks without timestamps from timeline', () => {
@@ -377,7 +405,7 @@ describe('ScanDetailComponent', () => {
     });
     const timeline = fixture.nativeElement.querySelector('.card.bg-base-200');
     expect(timeline).toBeTruthy();
-    const bars = timeline.querySelectorAll('.rounded');
+    const bars = timeline.querySelectorAll('.rounded-sm');
     expect(bars.length).toBe(1);
   });
 });

--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -134,28 +134,35 @@ const GET_BUILD_SCAN = gql`
         @if (getTimeline(scan.tasks.edges); as timeline) {
           <div class="card bg-base-200 mb-6">
             <div class="card-body p-4">
-              <h4 class="font-semibold mb-2">Timeline</h4>
-              @for (item of timeline.items; track item.id) {
+              <h4 class="font-semibold mb-2">
+                Timeline
+                <span class="font-normal text-sm opacity-60 ml-2">{{ timeline.lanes.length }} worker{{ timeline.lanes.length !== 1 ? 's' : '' }}</span>
+              </h4>
+              @for (lane of timeline.lanes; track $index) {
                 <div class="flex items-center gap-2 py-0.5">
-                  <span class="font-mono text-xs w-48 truncate text-right shrink-0" [title]="item.taskPath">{{ item.taskPath }}</span>
-                  <div class="relative flex-1 h-5">
-                    <div
-                      class="absolute top-0 h-full rounded tooltip"
-                      [class.bg-success]="item.outcome === 'Success'"
-                      [class.opacity-60]="item.outcome === 'UpToDate'"
-                      [class.bg-info]="item.outcome === 'FromCache'"
-                      [class.bg-error]="item.outcome === 'Failed'"
-                      [class.bg-warning]="item.outcome === 'Skipped'"
-                      [class.bg-neutral]="item.outcome !== 'Success' && item.outcome !== 'UpToDate' && item.outcome !== 'FromCache' && item.outcome !== 'Failed' && item.outcome !== 'Skipped'"
-                      [attr.data-tip]="item.taskPath + ' — ' + formatDuration(item.durationMs)"
-                      [style.left.%]="item.leftPct"
-                      [style.width.%]="item.widthPct">
-                    </div>
+                  <span class="text-xs w-20 text-right shrink-0 opacity-50">Worker {{ $index + 1 }}</span>
+                  <div class="relative flex-1 h-6">
+                    @for (item of lane; track item.id) {
+                      <div
+                        class="absolute top-0 h-full rounded-sm tooltip cursor-default overflow-hidden text-xs text-base-content/80 leading-6 px-1 whitespace-nowrap"
+                        [class.bg-success]="item.outcome === 'Success' || item.outcome === 'UpToDate'"
+                        [class.bg-info]="item.outcome === 'FromCache'"
+                        [class.bg-error]="item.outcome === 'Failed'"
+                        [class.bg-warning]="item.outcome === 'Skipped'"
+                        [class.bg-neutral]="!isKnownOutcome(item.outcome)"
+                        [attr.data-tip]="item.taskPath + ' — ' + formatDuration(item.durationMs)"
+                        [style.left.%]="item.leftPct"
+                        [style.width.%]="item.widthPct">
+                        @if (item.widthPct > 5) {
+                          {{ item.taskPath }}
+                        }
+                      </div>
+                    }
                   </div>
                 </div>
               }
               <div class="flex items-center gap-2 pt-1">
-                <span class="w-48 shrink-0"></span>
+                <span class="w-20 shrink-0"></span>
                 <div class="relative flex-1 flex justify-between text-xs opacity-50">
                   <span>0ms</span>
                   @if (timeline.duration > 0) {
@@ -272,51 +279,64 @@ export class ScanDetailComponent {
     map(result => result.data.buildScan)
   );
 
-  getTimeline(edges: any[]): { items: any[]; duration: number } | null {
-    const tasks = edges.filter(
-      (e: any) => e.node.startTimestamp != null && e.node.finishTimestamp != null
-    );
+  getTimeline(edges: any[]): { lanes: any[][]; duration: number } | null {
+    const tasks = edges
+      .filter((e: any) => e.node.startTimestamp != null && e.node.finishTimestamp != null)
+      .map((e: any) => ({
+        id: e.node.id,
+        taskPath: e.node.taskPath,
+        outcome: e.node.outcome,
+        start: e.node.startTimestamp as number,
+        finish: e.node.finishTimestamp as number,
+      }))
+      .sort((a, b) => a.start - b.start || a.finish - b.finish);
+
     if (tasks.length === 0) return null;
 
-    let minStart = Infinity;
-    let maxFinish = -Infinity;
-    for (const e of tasks) {
-      if (e.node.startTimestamp < minStart) minStart = e.node.startTimestamp;
-      if (e.node.finishTimestamp > maxFinish) maxFinish = e.node.finishTimestamp;
-    }
+    const minStart = tasks[0].start;
+    const maxFinish = tasks.reduce((max, t) => Math.max(max, t.finish), -Infinity);
     const duration = maxFinish - minStart;
 
-    if (duration === 0) {
-      return {
-        duration: 0,
-        items: tasks.map((e: any) => ({
-          id: e.node.id,
-          taskPath: e.node.taskPath,
-          outcome: e.node.outcome,
-          durationMs: 0,
-          leftPct: 0,
-          widthPct: 100,
-        })),
+    // Greedy lane assignment: place each task in the first lane where it fits
+    const lanes: any[][] = [];
+    const laneEnds: number[] = [];
+
+    for (const task of tasks) {
+      const taskDuration = Math.max(task.finish - task.start, 0);
+      const leftPct = duration > 0 ? ((task.start - minStart) / duration) * 100 : 0;
+      const widthPct = duration > 0
+        ? Math.min(Math.max((taskDuration / duration) * 100, 0.3), 100 - leftPct)
+        : 100;
+
+      const item = {
+        id: task.id,
+        taskPath: task.taskPath,
+        outcome: task.outcome,
+        durationMs: taskDuration,
+        leftPct,
+        widthPct,
       };
+
+      let placed = false;
+      for (let i = 0; i < laneEnds.length; i++) {
+        if (task.start >= laneEnds[i]) {
+          lanes[i].push(item);
+          laneEnds[i] = task.finish;
+          placed = true;
+          break;
+        }
+      }
+      if (!placed) {
+        lanes.push([item]);
+        laneEnds.push(task.finish);
+      }
     }
 
-    return {
-      duration,
-      items: tasks.map((e: any) => {
-        const start = e.node.startTimestamp - minStart;
-        const taskDuration = Math.max(e.node.finishTimestamp - e.node.startTimestamp, 0);
-        const leftPct = (start / duration) * 100;
-        const widthPct = Math.min(Math.max((taskDuration / duration) * 100, 0.5), 100 - leftPct);
-        return {
-          id: e.node.id,
-          taskPath: e.node.taskPath,
-          outcome: e.node.outcome,
-          durationMs: taskDuration,
-          leftPct,
-          widthPct,
-        };
-      }),
-    };
+    return { lanes, duration };
+  }
+
+  isKnownOutcome(outcome: string): boolean {
+    return ['Success', 'UpToDate', 'FromCache', 'Failed', 'Skipped'].includes(outcome);
   }
 
   formatDuration(ms: number): string {


### PR DESCRIPTION
## Summary
- Replace flat one-row-per-task timeline with a Gantt-style swimlane chart
- Greedy interval scheduling assigns tasks to worker lanes based on overlapping execution windows
- Overlapping tasks appear in separate lanes; sequential tasks share a lane
- Lane count reflects actual build concurrency (displayed as "N workers")
- Task bars show task path inline when wide enough, with tooltip for all bars

## Test plan
- [x] Overlapping tasks assigned to separate worker lanes
- [x] Sequential tasks (non-overlapping) share the same lane
- [x] Color-coding by outcome preserved (Success, FromCache, Failed, etc.)
- [x] Tasks without timestamps excluded from timeline
- [x] All 25 existing tests pass