### PR TITLE
fix: sort Gantt timeline tasks by start time

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
@@ -364,6 +364,25 @@ describe('ScanDetailComponent', () => {
     expect(bars[2].classList.contains('bg-error')).toBe(true);
   });
 
+  it('should sort timeline tasks by start time', () => {
+    flushQuery({
+      taskCount: 3,
+      tasks: {
+        edges: [
+          buildTaskEdge({ id: 'T3', taskPath: ':late', startTimestamp: 200, finishTimestamp: 300 }),
+          buildTaskEdge({ id: 'T1', taskPath: ':early', startTimestamp: 0, finishTimestamp: 100 }),
+          buildTaskEdge({ id: 'T2', taskPath: ':middle', startTimestamp: 100, finishTimestamp: 200 }),
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    const timeline = fixture.nativeElement.querySelector('.card.bg-base-200');
+    const labels = timeline.querySelectorAll('span.font-mono');
+    expect(labels[0].textContent.trim()).toBe(':early');
+    expect(labels[1].textContent.trim()).toBe(':middle');
+    expect(labels[2].textContent.trim()).toBe(':late');
+  });
+
   it('should exclude tasks without timestamps from timeline', () => {
     flushQuery({
       taskCount: 2,

--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -285,11 +285,11 @@ export class ScanDetailComponent {
       if (e.node.finishTimestamp > maxFinish) maxFinish = e.node.finishTimestamp;
     }
     const duration = maxFinish - minStart;
+    const sorted = [...tasks].sort(
+      (a: any, b: any) => a.node.startTimestamp - b.node.startTimestamp
+    );
 
     if (duration === 0) {
-      const sorted = [...tasks].sort(
-        (a: any, b: any) => a.node.startTimestamp - b.node.startTimestamp
-      );
       return {
         duration: 0,
         items: sorted.map((e: any) => ({
@@ -302,10 +302,6 @@ export class ScanDetailComponent {
         })),
       };
     }
-
-    const sorted = [...tasks].sort(
-      (a: any, b: any) => a.node.startTimestamp - b.node.startTimestamp
-    );
 
     return {
       duration,


### PR DESCRIPTION
## Summary
- Sort timeline tasks by `startTimestamp` so the Gantt chart displays tasks in chronological order (earliest at top)
- Applies to both the normal and zero-duration edge cases in `getTimeline()`

## Test plan
- [x] Unit tests pass (`aspect test //angular/projects/build-scan-web:test`)
- [x] Visual verification: open a build scan detail page and confirm tasks are ordered top-to-bottom by start time