### PR TITLE
feat: add sidebar to build scan detail page

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { TestBed, ComponentFixture } from "@angular/core/testing";
 import {
   ApolloTestingModule,
@@ -106,7 +106,22 @@ describe("ScanDetailComponent", () => {
 
   it("should render section navigation", () => {
     flushQuery();
-    const navItems = fixture.nativeElement.querySelectorAll("nav a");
+    const navItems = fixture.nativeElement.querySelectorAll("nav button");
     expect(navItems.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("should update activeSection on scrollToSection", () => {
+    flushQuery();
+    // jsdom doesn't implement scrollIntoView; stub it on the target element
+    const section = fixture.nativeElement.querySelector("#task-timeline");
+    section.scrollIntoView = vi.fn();
+
+    fixture.componentInstance.scrollToSection("task-timeline");
+
+    expect(fixture.componentInstance.activeSection()).toBe("task-timeline");
+    expect(section.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
   });
 });

--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -6,7 +6,7 @@ import {
   signal,
 } from "@angular/core";
 import { Apollo, gql } from "apollo-angular";
-import { AsyncPipe } from "@angular/common";
+import { AsyncPipe, DOCUMENT } from "@angular/common";
 import { filter, map, switchMap, tap } from "rxjs";
 import { toObservable } from "@angular/core/rxjs-interop";
 import { TaskTimelineComponent } from "./task-timeline/task-timeline.component";
@@ -118,12 +118,14 @@ const GET_BUILD_SCAN = gql`
               [taskCount]="scan.taskCount"
             />
           </section>
-          <section id="tests-table" class="scroll-mt-4">
-            <app-tests-table
-              [testEdges]="scan.tests.edges"
-              [testCount]="scan.testCount"
-            />
-          </section>
+          @if (scan.tests) {
+            <section id="tests-table" class="scroll-mt-4">
+              <app-tests-table
+                [testEdges]="scan.tests.edges"
+                [testCount]="scan.testCount"
+              />
+            </section>
+          }
         </main>
       </div>
     }
@@ -133,6 +135,7 @@ const GET_BUILD_SCAN = gql`
 export class ScanDetailComponent {
   id = input.required<string>();
   private apollo = inject(Apollo);
+  private doc = inject(DOCUMENT);
   activeSection = signal("cache-breakdown");
 
   scan$ = toObservable(this.id).pipe(
@@ -170,7 +173,7 @@ export class ScanDetailComponent {
 
   scrollToSection(sectionId: string) {
     this.activeSection.set(sectionId);
-    const el = document.getElementById(sectionId);
+    const el = this.doc.getElementById(sectionId);
     el?.scrollIntoView({ behavior: "smooth", block: "start" });
   }
 }

--- a/angular/projects/build-scan-web/src/app/scans/scan-sidebar/scan-sidebar.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-sidebar/scan-sidebar.component.ts
@@ -6,6 +6,7 @@ import {
   output,
 } from "@angular/core";
 import { DatePipe } from "@angular/common";
+import { RouterLink } from "@angular/router";
 
 interface SectionNav {
   id: string;
@@ -15,7 +16,7 @@ interface SectionNav {
 
 @Component({
   selector: "app-scan-sidebar",
-  imports: [DatePipe],
+  imports: [DatePipe, RouterLink],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (scan(); as scan) {
@@ -157,8 +158,9 @@ interface SectionNav {
             Sections
           </div>
           @for (section of sections(); track section.id) {
-            <a
-              class="flex items-center gap-2 px-2.5 py-2 rounded-md text-sm cursor-pointer transition-all duration-150 no-underline"
+            <button
+              type="button"
+              class="flex items-center gap-2 px-2.5 py-2 rounded-md text-sm cursor-pointer transition-all duration-150"
               [class]="
                 activeSection() === section.id
                   ? 'bg-primary/15 text-primary'
@@ -166,9 +168,11 @@ interface SectionNav {
               "
               (click)="navigateToSection(section.id)"
             >
-              <span class="w-5 text-center">{{ section.icon }}</span>
+              <span class="w-5 text-center" aria-hidden="true">{{
+                section.icon
+              }}</span>
               <span>{{ section.label }}</span>
-            </a>
+            </button>
           }
         </nav>
 
@@ -176,7 +180,7 @@ interface SectionNav {
         <div class="mt-auto pt-3 border-t border-base-300">
           <a
             class="back-link link link-hover text-xs opacity-50 hover:opacity-80"
-            href="/scans"
+            routerLink="/scans"
             >&larr; All Scans</a
           >
         </div>


### PR DESCRIPTION
## Summary
- Replace single-column layout with a two-column dashboard: sticky sidebar (260px) + scrollable main content
- New `ScanSidebarComponent` absorbs build metadata (identity, stats, environment, requested tasks) and adds section navigation with smooth scrolling
- Styled entirely with Tailwind CSS + DaisyUI semantic tokens for automatic theme support

## Screenshot
![sidebar](https://github.com/user-attachments/assets/sidebar-preview.png)

## Test plan
- [x] All 53 unit tests pass (`aspect test //angular/projects/build-scan-web:test`)
- [x] Production build succeeds (`aspect build //angular/projects/build-scan-web`)
- [x] Visual verification with agent-browser confirms sidebar renders correctly with scan data
- [x] Verify section navigation smooth-scrolls to correct sections
- [x] Verify sidebar displays correctly on different DaisyUI themes (light/dark)