### PR TITLE
feat: print clickable web UI URL on server startup

### DIFF
--- a/build-scan/server/src/main.rs
+++ b/build-scan/server/src/main.rs
@@ -102,8 +102,16 @@ async fn main() {
             std::process::exit(1);
         }
     };
-    info!("Build scan server listening on http://{}", addr);
-    info!("GraphiQL IDE available at http://{}/graphiql", addr);
+    let local_addr = listener.local_addr().expect("Failed to get local address");
+    info!("Build scan server listening on http://{local_addr}");
+    info!("  Local:    http://localhost:{}/", local_addr.port());
+    info!(
+        "  GraphiQL: http://localhost:{}/graphiql",
+        local_addr.port()
+    );
+    if config.spa_dir.is_some() {
+        info!("  Web UI:   http://localhost:{}/web/", local_addr.port());
+    }
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())


### PR DESCRIPTION
## Summary
- Use `localhost` instead of `0.0.0.0` in server startup log messages so URLs are clickable in terminals
- Add a new log line showing the web UI URL (`/web/`) when `SPA_DIR` is configured

## Test plan
- [x] `aspect build //build-scan/server/src:main` passes
- [x] `aspect test //build-scan/server/...` passes