### PR TITLE
ci(renovate): add post-upgrade tasks for Maven and Cargo deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,15 +3,6 @@
   "extends": ["config:recommended", ":approveMajorUpdates", ":automergeAll"],
   "packageRules": [
     {
-      "matchManagers": ["bazel-module"],
-      "matchDatasources": ["maven"],
-      "postUpgradeTasks": {
-        "commands": ["env REPIN=1 bazel run @maven//:pin"],
-        "fileFilters": ["maven_install.json"],
-        "executionMode": "update"
-      }
-    },
-    {
       "matchManagers": ["cargo"],
       "postUpgradeTasks": {
         "commands": ["bazel mod deps --lockfile_mode=update"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":approveMajorUpdates", ":automergeAll"],
+  "packageRules": [
+    {
+      "matchManagers": ["bazel-module"],
+      "matchDatasources": ["maven"],
+      "postUpgradeTasks": {
+        "commands": ["env REPIN=1 bazel run @maven//:pin"],
+        "fileFilters": ["maven_install.json"],
+        "executionMode": "update"
+      }
+    },
+    {
+      "matchManagers": ["cargo"],
+      "postUpgradeTasks": {
+        "commands": ["bazel mod deps --lockfile_mode=update"],
+        "fileFilters": ["MODULE.bazel.lock"],
+        "executionMode": "update"
+      }
+    }
+  ],
   "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
## Summary
- Add Renovate `packageRules` with `postUpgradeTasks` for Cargo dependencies
- Cargo upgrades now automatically update `MODULE.bazel.lock` via `bazel mod deps --lockfile_mode=update`