### PR TITLE
feat: add duration_ms to cache operations and improve frontend visualization

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/cache-breakdown/cache-breakdown.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/cache-breakdown/cache-breakdown.component.spec.ts
@@ -13,6 +13,7 @@ function buildTaskEdge(
       cacheable: null,
       cachingDisabledReason: null,
       originExecutionTime: null,
+      cacheOperations: null,
       ...overrides,
     },
   };
@@ -71,7 +72,7 @@ describe("CacheBreakdownComponent", () => {
   it("should show legend entries for present categories only", () => {
     render([buildTaskEdge("FromCache"), buildTaskEdge("UpToDate")]);
     const legendItems = fixture.nativeElement.querySelectorAll(
-      ".flex.flex-wrap .flex.items-center",
+      ".flex.flex-wrap:not([data-testid='tier-breakdown']) .flex.items-center",
     );
     expect(legendItems.length).toBe(2);
     const labels = Array.from(legendItems).map((el: any) =>

--- a/angular/projects/build-scan-web/src/app/scans/cache-breakdown/cache-breakdown.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/cache-breakdown/cache-breakdown.component.ts
@@ -21,6 +21,7 @@ interface TaskEdge {
     cacheable: boolean | null;
     cachingDisabledReason: string | null;
     originExecutionTime: number | null;
+    cacheOperations: { operationType: string; succeeded: boolean }[] | null;
   };
 }
 
@@ -96,6 +97,20 @@ const CATEGORY_ORDER = [
                 </div>
               </div>
             }
+            <div class="mt-3 flex flex-wrap gap-2">
+              <div class="flex items-center gap-1.5 text-sm">
+                <span class="badge badge-sm badge-success">{{ tierBreakdown().localHits }}</span>
+                <span class="opacity-70">Local hits</span>
+              </div>
+              <div class="flex items-center gap-1.5 text-sm">
+                <span class="badge badge-sm" style="background:oklch(72% 0.15 230);color:white">{{ tierBreakdown().remoteHits }}</span>
+                <span class="opacity-70">Remote hits</span>
+              </div>
+              <div class="flex items-center gap-1.5 text-sm">
+                <span class="badge badge-sm badge-ghost">{{ tierBreakdown().misses }}</span>
+                <span class="opacity-70">Misses</span>
+              </div>
+            </div>
             @if (missPatterns().length > 0) {
               <div class="mt-3">
                 <div class="text-xs font-semibold opacity-70 mb-1">
@@ -180,6 +195,36 @@ export class CacheBreakdownComponent {
     return [...patterns.entries()]
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count }));
+  });
+
+  tierBreakdown = computed(() => {
+    const edges = this.taskEdges() as TaskEdge[];
+    let localHits = 0;
+    let remoteHits = 0;
+    let misses = 0;
+    for (const e of edges) {
+      const ops = e.node.cacheOperations ?? [];
+      const localHit = ops.some(
+        (op) => op.operationType === "LocalLoad" && op.succeeded,
+      );
+      const remoteHit = ops.some(
+        (op) => op.operationType === "RemoteLoad" && op.succeeded,
+      );
+      const hasLoadOps = ops.some(
+        (op) => op.operationType === "LocalLoad" || op.operationType === "RemoteLoad",
+      );
+      const allLoadsFailed =
+        hasLoadOps &&
+        ops
+          .filter(
+            (op) => op.operationType === "LocalLoad" || op.operationType === "RemoteLoad",
+          )
+          .every((op) => !op.succeeded);
+      if (localHit) localHits++;
+      else if (remoteHit) remoteHits++;
+      else if (allLoadsFailed) misses++;
+    }
+    return { localHits, remoteHits, misses };
   });
 
   constructor() {

--- a/angular/projects/build-scan-web/src/app/scans/cache-breakdown/cache-breakdown.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/cache-breakdown/cache-breakdown.component.ts
@@ -97,7 +97,7 @@ const CATEGORY_ORDER = [
                 </div>
               </div>
             }
-            <div class="mt-3 flex flex-wrap gap-2">
+            <div class="mt-3 flex flex-wrap gap-2" data-testid="tier-breakdown">
               <div class="flex items-center gap-1.5 text-sm">
                 <span class="badge badge-sm badge-success">{{ tierBreakdown().localHits }}</span>
                 <span class="opacity-70">Local hits</span>

--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -63,6 +63,7 @@ const GET_BUILD_SCAN = gql`
               succeeded
               archiveSize
               cacheKey
+              durationMs
             }
           }
           cursor

--- a/angular/projects/build-scan-web/src/app/scans/task-cache-detail/task-cache-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-cache-detail/task-cache-detail.component.ts
@@ -24,6 +24,7 @@ interface CacheOperation {
   succeeded: boolean;
   archiveSize: number | null;
   cacheKey: string | null;
+  durationMs: number | null;
 }
 
 @Component({
@@ -154,8 +155,15 @@ export class TaskCacheDetailComponent {
       RemoteStore: "Remote store",
     };
     const label = labels[op.operationType] ?? op.operationType;
+    const parts: string[] = [];
     if (op.archiveSize && op.archiveSize > 0) {
-      return prefix + " " + label + " (" + formatBytes(op.archiveSize) + ")";
+      parts.push(formatBytes(op.archiveSize));
+    }
+    if (op.durationMs != null) {
+      parts.push(this.formatMs(op.durationMs));
+    }
+    if (parts.length > 0) {
+      return prefix + " " + label + " (" + parts.join(", ") + ")";
     }
     return prefix + " " + label;
   }

--- a/build-scan/lib/src/assembly.rs
+++ b/build-scan/lib/src/assembly.rs
@@ -42,8 +42,8 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
     let mut jvm_event: Option<events::JvmEvent> = None;
     let mut requested_tasks: Vec<String> = Vec::new();
 
-    // Cache operation tracking: operation_id → (work_id, op_type, cache_key, started_archive_size)
-    let mut cache_op_started: HashMap<i64, (i64, CacheOperationType, Option<String>, Option<i64>)> =
+    // Cache operation tracking: operation_id → (work_id, op_type, cache_key, started_archive_size, started_timestamp)
+    let mut cache_op_started: HashMap<i64, (i64, CacheOperationType, Option<String>, Option<i64>, i64)> =
         HashMap::new();
     let mut cache_op_finished: HashMap<i64, CacheOpFinished> = HashMap::new();
 
@@ -209,6 +209,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         CacheOperationType::LocalLoad,
                         e.cache_key.clone(),
                         None,
+                        frame.timestamp,
                     ),
                 );
             }
@@ -223,6 +224,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         failure_id: e.failure_id,
                         remote_cache_location: None,
                         rejected_reason: None,
+                        finished_timestamp: Some(frame.timestamp),
                     },
                 );
             }
@@ -234,6 +236,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         CacheOperationType::RemoteLoad,
                         e.cache_key.clone(),
                         None,
+                        frame.timestamp,
                     ),
                 );
             }
@@ -248,6 +251,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         failure_id: e.failure_id,
                         remote_cache_location: e.remote_cache_location.clone(),
                         rejected_reason: None,
+                        finished_timestamp: Some(frame.timestamp),
                     },
                 );
             }
@@ -259,6 +263,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         CacheOperationType::Pack,
                         e.cache_key.clone(),
                         None,
+                        frame.timestamp,
                     ),
                 );
             }
@@ -273,6 +278,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         failure_id: e.failure_id,
                         remote_cache_location: None,
                         rejected_reason: None,
+                        finished_timestamp: Some(frame.timestamp),
                     },
                 );
             }
@@ -284,6 +290,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         CacheOperationType::Unpack,
                         e.cache_key.clone(),
                         e.archive_size,
+                        frame.timestamp,
                     ),
                 );
             }
@@ -298,6 +305,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         failure_id: e.failure_id,
                         remote_cache_location: None,
                         rejected_reason: None,
+                        finished_timestamp: Some(frame.timestamp),
                     },
                 );
             }
@@ -309,6 +317,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         CacheOperationType::LocalStore,
                         e.cache_key.clone(),
                         e.archive_size,
+                        frame.timestamp,
                     ),
                 );
             }
@@ -323,6 +332,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         failure_id: e.failure_id,
                         remote_cache_location: None,
                         rejected_reason: None,
+                        finished_timestamp: Some(frame.timestamp),
                     },
                 );
             }
@@ -334,6 +344,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         CacheOperationType::RemoteStore,
                         e.cache_key.clone(),
                         e.archive_size,
+                        frame.timestamp,
                     ),
                 );
             }
@@ -348,6 +359,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         failure_id: e.failure_id,
                         remote_cache_location: e.remote_cache_location.clone(),
                         rejected_reason: e.rejected_reason,
+                        finished_timestamp: Some(frame.timestamp),
                     },
                 );
             }
@@ -477,9 +489,12 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
     let mut sorted_op_ids: Vec<_> = cache_op_started.keys().copied().collect();
     sorted_op_ids.sort();
     for op_id in &sorted_op_ids {
-        let (work_id, op_type, cache_key, started_archive_size) =
+        let (work_id, op_type, cache_key, started_archive_size, started_timestamp) =
             cache_op_started.get(op_id).unwrap();
         let finished = cache_op_finished.get(op_id);
+        let duration_ms = finished
+            .and_then(|f| f.finished_timestamp)
+            .map(|ft| ft - started_timestamp);
         let op = CacheOperation {
             operation_type: op_type.clone(),
             cache_key: cache_key.clone(),
@@ -492,6 +507,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
             failure_id: finished.and_then(|f| f.failure_id),
             remote_cache_location: finished.and_then(|f| f.remote_cache_location.clone()),
             rejected_reason: finished.and_then(|f| f.rejected_reason),
+            duration_ms,
         };
         task_cache_ops
             .entry(TaskId::new(*work_id))
@@ -656,6 +672,7 @@ struct CacheOpFinished {
     failure_id: Option<i64>,
     remote_cache_location: Option<String>,
     rejected_reason: Option<u64>,
+    finished_timestamp: Option<i64>,
 }
 
 struct FinishedInfo {

--- a/build-scan/lib/src/assembly.rs
+++ b/build-scan/lib/src/assembly.rs
@@ -494,7 +494,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
         let finished = cache_op_finished.get(op_id);
         let duration_ms = finished
             .and_then(|f| f.finished_timestamp)
-            .map(|ft| ft - started_timestamp);
+            .map(|ft| (ft - started_timestamp).max(0));
         let op = CacheOperation {
             operation_type: op_type.clone(),
             cache_key: cache_key.clone(),
@@ -947,9 +947,76 @@ mod tests {
         assert_eq!(op.hit, Some(true));
         assert_eq!(op.archive_size, Some(8192));
         assert_eq!(op.failure_id, None);
+        assert_eq!(op.duration_ms, Some(500)); // 3000 - 2500
         assert_eq!(op.stored, None);
         assert_eq!(op.remote_cache_location, None);
         assert_eq!(op.rejected_reason, None);
+    }
+
+    #[test]
+    fn test_assemble_cache_operation_duration_none_when_finished_missing() {
+        use events::{BuildCacheLocalLoadStartedEvent, TaskFinishedEvent, TaskIdentityEvent, TaskStartedEvent};
+        use models::CacheOperationType;
+
+        let task_id = TaskId::new(99);
+        let work_id: i64 = 99;
+        let op_id: i64 = 200;
+
+        let events = vec![
+            (
+                frame(117, 1000),
+                DecodedEvent::TaskIdentity(TaskIdentityEvent {
+                    id: task_id,
+                    build_path: ":".into(),
+                    task_path: ":app:test".into(),
+                }),
+            ),
+            (
+                frame(1563, 2000),
+                DecodedEvent::TaskStarted(TaskStartedEvent {
+                    id: task_id,
+                    build_path: ":".into(),
+                    path: ":app:test".into(),
+                    class_name: None,
+                }),
+            ),
+            (
+                frame(2074, 5000),
+                DecodedEvent::TaskFinished(TaskFinishedEvent {
+                    id: task_id,
+                    path: ":app:test".into(),
+                    outcome: Some(3),
+                    cacheable: Some(true),
+                    caching_disabled_reason_category: None,
+                    caching_disabled_explanation: None,
+                    origin_build_invocation_id: None,
+                    origin_build_cache_key: None,
+                    origin_execution_time: None,
+                    actionable: Some(true),
+                    skip_reason_message: None,
+                    up_to_date_messages: None,
+                }),
+            ),
+            (
+                frame(144, 3000),
+                DecodedEvent::BuildCacheLocalLoadStarted(BuildCacheLocalLoadStartedEvent {
+                    work_id,
+                    id: op_id,
+                    cache_key: Some("def456".into()),
+                }),
+            ),
+            // No BuildCacheLocalLoadFinished event — simulates truncated/incomplete scan
+        ];
+
+        let payload = assemble(events);
+        assert_eq!(payload.tasks.len(), 1);
+        let task = &payload.tasks[0];
+        assert_eq!(task.cache_operations.len(), 1);
+
+        let op = &task.cache_operations[0];
+        assert_eq!(op.operation_type, CacheOperationType::LocalLoad);
+        assert_eq!(op.duration_ms, None); // No finished event → no duration
+        assert_eq!(op.hit, None);
     }
 
     #[test]

--- a/build-scan/lib/src/models.rs
+++ b/build-scan/lib/src/models.rs
@@ -109,6 +109,8 @@ pub struct CacheOperation {
     pub remote_cache_location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rejected_reason: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/build-scan/server/db/migrations/src/BUILD.bazel
+++ b/build-scan/server/db/migrations/src/BUILD.bazel
@@ -10,6 +10,7 @@ rust_library(
         "sql/004_task_caching_reason.sql",
         "sql/005_task_cache_detail.sql",
         "sql/006_task_cache_operations.sql",
+        "sql/007_add_duration_ms_to_cache_operations.sql",
     ],
     visibility = ["//visibility:public"],
     deps = ["@crates//:sqlx"],

--- a/build-scan/server/db/migrations/src/lib.rs
+++ b/build-scan/server/db/migrations/src/lib.rs
@@ -55,6 +55,16 @@ pub static MIGRATOR: Migrator = Migrator {
             checksum: Cow::Borrowed(&[]),
             no_tx: false,
         },
+        Migration {
+            version: 7,
+            description: Cow::Borrowed("add duration_ms to cache operations"),
+            migration_type: MigrationType::Simple,
+            sql: Cow::Borrowed(include_str!(
+                "sql/007_add_duration_ms_to_cache_operations.sql"
+            )),
+            checksum: Cow::Borrowed(&[]),
+            no_tx: false,
+        },
     ]),
     ignore_missing: false,
     locking: true,

--- a/build-scan/server/db/migrations/src/sql/007_add_duration_ms_to_cache_operations.sql
+++ b/build-scan/server/db/migrations/src/sql/007_add_duration_ms_to_cache_operations.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task_cache_operations ADD COLUMN duration_ms INTEGER;

--- a/build-scan/server/db/src/lib.rs
+++ b/build-scan/server/db/src/lib.rs
@@ -62,6 +62,7 @@ struct CacheOperationRow {
     succeeded: i64,
     archive_size: Option<i64>,
     cache_key: Option<String>,
+    duration_ms: Option<i64>,
 }
 
 #[derive(Debug, sqlx::FromRow)]
@@ -286,6 +287,7 @@ impl TryFrom<CacheOperationRow> for domain::CacheOperation {
             succeeded: row.succeeded != 0,
             archive_size: row.archive_size,
             cache_key: row.cache_key,
+            duration_ms: row.duration_ms,
         })
     }
 }
@@ -299,6 +301,7 @@ impl From<&domain::CacheOperation> for CacheOperationRow {
             succeeded: if op.succeeded { 1 } else { 0 },
             archive_size: op.archive_size,
             cache_key: op.cache_key.clone(),
+            duration_ms: op.duration_ms,
         }
     }
 }
@@ -549,8 +552,8 @@ pub async fn insert_cache_operation<'c, E: sqlx::Executor<'c, Database = sqlx::S
 ) -> Result<()> {
     let row = CacheOperationRow::from(op);
     sqlx::query(
-        "INSERT INTO task_cache_operations (id, task_id, operation_type, succeeded, archive_size, cache_key) \
-         VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO task_cache_operations (id, task_id, operation_type, succeeded, archive_size, cache_key, duration_ms) \
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&row.id)
     .bind(&row.task_id)
@@ -558,6 +561,7 @@ pub async fn insert_cache_operation<'c, E: sqlx::Executor<'c, Database = sqlx::S
     .bind(row.succeeded)
     .bind(row.archive_size)
     .bind(row.cache_key.as_deref())
+    .bind(row.duration_ms)
     .execute(executor)
     .await?;
     Ok(())
@@ -568,7 +572,7 @@ pub async fn list_cache_operations(
     task_id: &str,
 ) -> Result<Vec<domain::CacheOperation>> {
     let rows = sqlx::query_as::<_, CacheOperationRow>(
-        "SELECT id, task_id, operation_type, succeeded, archive_size, cache_key \
+        "SELECT id, task_id, operation_type, succeeded, archive_size, cache_key, duration_ms \
          FROM task_cache_operations WHERE task_id = ? ORDER BY rowid",
     )
     .bind(task_id)

--- a/build-scan/server/domain/src/lib.rs
+++ b/build-scan/server/domain/src/lib.rs
@@ -406,4 +406,5 @@ pub struct CacheOperation {
     pub succeeded: bool,
     pub archive_size: Option<i64>,
     pub cache_key: Option<String>,
+    pub duration_ms: Option<i64>,
 }

--- a/build-scan/server/graphql/src/lib.rs
+++ b/build-scan/server/graphql/src/lib.rs
@@ -337,6 +337,10 @@ impl CacheOperation {
     fn cache_key(&self) -> Option<&str> {
         self.op.cache_key.as_deref()
     }
+
+    fn duration_ms(&self) -> Option<f64> {
+        self.op.duration_ms.map(|d| d as f64)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/build-scan/server/service/src/lib.rs
+++ b/build-scan/server/service/src/lib.rs
@@ -220,6 +220,7 @@ impl BuildScanService {
                             succeeded,
                             archive_size: cache_op.archive_size,
                             cache_key: cache_op.cache_key.clone(),
+                            duration_ms: cache_op.duration_ms,
                         };
                         db::insert_cache_operation(&mut *tx, &domain_op)
                             .await


### PR DESCRIPTION
## Summary

- Add `duration_ms` tracking to cache operations by capturing event frame timestamps during assembly and computing the Started→Finished delta
- Propagate `duration_ms` through the full Rust backend stack: parser model → domain → DB migration → service → GraphQL
- Display duration and archive size per cache operation in the frontend flow narrative
- Add cache tier breakdown (local hits / remote hits / misses) to the cache breakdown component

Closes #132

## Test plan

- [x] `bazelisk build //build-scan/...` passes
- [x] `bazelisk test //build-scan/...` passes
- [x] `bazelisk build //angular/...` passes