### PR TITLE
chore(deps): regenerate preset.bazelrc on bazelrc-preset.bzl updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,15 @@
         "fileFilters": ["MODULE.bazel.lock"],
         "executionMode": "update"
       }
+    },
+    {
+      "matchManagers": ["bazel_module"],
+      "matchPackageNames": ["bazelrc-preset.bzl"],
+      "postUpgradeTasks": {
+        "commands": ["bazel run //tools:preset.update"],
+        "fileFilters": ["tools/preset.bazelrc"],
+        "executionMode": "update"
+      }
     }
   ],
   "postUpdateOptions": ["gomodTidy"]


### PR DESCRIPTION
## Summary
- Add Renovate `postUpgradeTasks` rule for `bazelrc-preset.bzl` updates via the `bazel_module` manager
- Runs `bazel run //tools:preset.update` and commits `tools/preset.bazelrc` alongside version bumps