### PR TITLE
feat: capture test duration and failure details in build scans

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -73,6 +73,12 @@ const GET_BUILD_SCAN = gql`
           endCursor
         }
       }
+      testSummary {
+        passed
+        failed
+        skipped
+        totalDurationMs
+      }
       tests(first: $firstTests, after: $afterTests)
         @include(if: $includeTests) {
         edges {
@@ -82,6 +88,9 @@ const GET_BUILD_SCAN = gql`
             methodName
             executorName
             outcome
+            durationMs
+            failureMessage
+            failureStacktrace
           }
           cursor
         }
@@ -135,6 +144,7 @@ const GET_BUILD_SCAN = gql`
               <app-tests-table
                 [testEdges]="scan.tests.edges"
                 [testCount]="scan.testCount"
+                [testSummary]="scan.testSummary"
               />
             </section>
           }

--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -73,7 +73,7 @@ const GET_BUILD_SCAN = gql`
           endCursor
         }
       }
-      testSummary {
+      testSummary @include(if: $includeTests) {
         passed
         failed
         skipped

--- a/angular/projects/build-scan-web/src/app/scans/tests-table/tests-table.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/tests-table/tests-table.component.spec.ts
@@ -10,6 +10,9 @@ function buildTestEdge(overrides: Record<string, unknown> = {}) {
       methodName: "testSomething",
       executorName: "Gradle Test Executor 1",
       outcome: "Passed",
+      durationMs: 123,
+      failureMessage: null,
+      failureStacktrace: null,
       ...overrides,
     },
     cursor: "tc1",
@@ -51,6 +54,7 @@ describe("TestsTableComponent", () => {
       "Class Name",
       "Method Name",
       "Outcome",
+      "Duration",
       "Executor",
     ]);
   });
@@ -61,7 +65,8 @@ describe("TestsTableComponent", () => {
     expect(cells[0].textContent.trim()).toBe("com.example.FooTest");
     expect(cells[1].textContent.trim()).toBe("testSomething");
     expect(cells[2].textContent).toContain("Passed");
-    expect(cells[3].textContent.trim()).toBe("Gradle Test Executor 1");
+    expect(cells[3].textContent.trim()).toBe("123ms");
+    expect(cells[4].textContent.trim()).toBe("Gradle Test Executor 1");
   });
 
   it("should apply badge-success for Passed outcome", () => {
@@ -91,7 +96,19 @@ describe("TestsTableComponent", () => {
   it("should show dash for null executorName", () => {
     render([buildTestEdge({ executorName: null })]);
     const cells = fixture.nativeElement.querySelectorAll("tbody td");
+    expect(cells[4].textContent.trim()).toBe("—");
+  });
+
+  it("should show dash for null durationMs", () => {
+    render([buildTestEdge({ durationMs: null })]);
+    const cells = fixture.nativeElement.querySelectorAll("tbody td");
     expect(cells[3].textContent.trim()).toBe("—");
+  });
+
+  it("should format duration in seconds for large values", () => {
+    render([buildTestEdge({ durationMs: 1500 })]);
+    const cells = fixture.nativeElement.querySelectorAll("tbody td");
+    expect(cells[3].textContent.trim()).toBe("1.50s");
   });
 
   it("should render multiple test rows", () => {
@@ -104,11 +121,32 @@ describe("TestsTableComponent", () => {
           methodName: "testOther",
           executorName: null,
           outcome: "Failed",
+          durationMs: 50,
+          failureMessage: "expected true but was false",
+          failureStacktrace: "at com.example.BarTest.testOther(BarTest.java:10)",
         },
         cursor: "tc2",
       },
     ]);
     const rows = fixture.nativeElement.querySelectorAll("tbody tr");
     expect(rows.length).toBe(2);
+  });
+
+  it("should show summary stats when testSummary is provided", () => {
+    fixture.componentRef.setInput("testEdges", [buildTestEdge()]);
+    fixture.componentRef.setInput("testCount", 1);
+    fixture.componentRef.setInput("testSummary", {
+      passed: 5,
+      failed: 2,
+      skipped: 1,
+      totalDurationMs: 3000,
+    });
+    fixture.detectChanges();
+    const badges = fixture.nativeElement.querySelectorAll(".badge-lg");
+    expect(badges.length).toBe(4);
+    expect(badges[0].textContent).toContain("5 passed");
+    expect(badges[1].textContent).toContain("2 failed");
+    expect(badges[2].textContent).toContain("1 skipped");
+    expect(badges[3].textContent).toContain("3.00s total");
   });
 });

--- a/angular/projects/build-scan-web/src/app/scans/tests-table/tests-table.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/tests-table/tests-table.component.ts
@@ -1,4 +1,9 @@
-import { Component, ChangeDetectionStrategy, input } from "@angular/core";
+import {
+  Component,
+  ChangeDetectionStrategy,
+  input,
+  signal,
+} from "@angular/core";
 
 @Component({
   selector: "app-tests-table",
@@ -7,6 +12,25 @@ import { Component, ChangeDetectionStrategy, input } from "@angular/core";
     @if (testCount() > 0) {
       <h3 class="text-xl font-bold mb-4 mt-8">Tests ({{ testCount() }})</h3>
 
+      @if (testSummary(); as summary) {
+        <div class="flex gap-2 mb-4 flex-wrap">
+          <span class="badge badge-success badge-lg">
+            {{ summary.passed }} passed
+          </span>
+          <span class="badge badge-error badge-lg">
+            {{ summary.failed }} failed
+          </span>
+          <span class="badge badge-warning badge-lg">
+            {{ summary.skipped }} skipped
+          </span>
+          @if (summary.totalDurationMs != null) {
+            <span class="badge badge-neutral badge-lg">
+              {{ formatDuration(summary.totalDurationMs) }} total
+            </span>
+          }
+        </div>
+      }
+
       <div class="overflow-x-auto">
         <table class="table table-zebra w-full">
           <thead>
@@ -14,12 +38,16 @@ import { Component, ChangeDetectionStrategy, input } from "@angular/core";
               <th>Class Name</th>
               <th>Method Name</th>
               <th>Outcome</th>
+              <th>Duration</th>
               <th>Executor</th>
             </tr>
           </thead>
           <tbody>
             @for (edge of testEdges(); track edge.node.id) {
-              <tr>
+              <tr
+                [class.cursor-pointer]="edge.node.outcome === 'Failed' && edge.node.failureMessage"
+                (click)="toggleExpanded(edge.node.id)"
+              >
                 <td class="font-mono text-sm">{{ edge.node.className }}</td>
                 <td class="font-mono text-sm">
                   {{ edge.node.methodName || "—" }}
@@ -34,10 +62,30 @@ import { Component, ChangeDetectionStrategy, input } from "@angular/core";
                     {{ edge.node.outcome || "—" }}
                   </span>
                 </td>
+                <td class="text-sm tabular-nums">
+                  {{ edge.node.durationMs != null ? formatDuration(edge.node.durationMs) : "—" }}
+                </td>
                 <td class="text-xs opacity-60">
                   {{ edge.node.executorName || "—" }}
                 </td>
               </tr>
+              @if (expandedIds().has(edge.node.id) && edge.node.failureMessage) {
+                <tr>
+                  <td colspan="5" class="bg-base-200 p-4">
+                    @if (edge.node.failureMessage) {
+                      <div class="mb-2">
+                        <span class="font-semibold text-error">Failure:</span>
+                        <span class="ml-2">{{ edge.node.failureMessage }}</span>
+                      </div>
+                    }
+                    @if (edge.node.failureStacktrace) {
+                      <pre
+                        class="text-xs overflow-x-auto max-h-64 overflow-y-auto bg-base-300 p-3 rounded"
+                      >{{ edge.node.failureStacktrace }}</pre>
+                    }
+                  </td>
+                </tr>
+              }
             }
           </tbody>
         </table>
@@ -48,4 +96,24 @@ import { Component, ChangeDetectionStrategy, input } from "@angular/core";
 export class TestsTableComponent {
   testEdges = input.required<any[]>();
   testCount = input.required<number>();
+  testSummary = input<any>();
+
+  expandedIds = signal<Set<string>>(new Set());
+
+  toggleExpanded(id: string) {
+    const current = this.expandedIds();
+    const next = new Set(current);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    this.expandedIds.set(next);
+  }
+
+  formatDuration(ms: number): string {
+    if (ms < 1) return "< 1ms";
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(2)}s`;
+  }
 }

--- a/angular/projects/build-scan-web/src/app/scans/tests-table/tests-table.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/tests-table/tests-table.component.ts
@@ -46,7 +46,11 @@ import {
             @for (edge of testEdges(); track edge.node.id) {
               <tr
                 [class.cursor-pointer]="edge.node.outcome === 'Failed' && edge.node.failureMessage"
-                (click)="toggleExpanded(edge.node.id)"
+                [attr.tabindex]="edge.node.outcome === 'Failed' && edge.node.failureMessage ? '0' : null"
+                [attr.aria-expanded]="edge.node.outcome === 'Failed' && edge.node.failureMessage ? expandedIds().has(edge.node.id) : null"
+                (click)="edge.node.outcome === 'Failed' && edge.node.failureMessage ? toggleExpanded(edge.node.id) : null"
+                (keydown.enter)="edge.node.outcome === 'Failed' && edge.node.failureMessage ? toggleExpanded(edge.node.id) : null"
+                (keydown.space)="edge.node.outcome === 'Failed' && edge.node.failureMessage ? toggleExpanded(edge.node.id) : null"
               >
                 <td class="font-mono text-sm">{{ edge.node.className }}</td>
                 <td class="font-mono text-sm">

--- a/build-scan/lib/src/assembly.rs
+++ b/build-scan/lib/src/assembly.rs
@@ -31,8 +31,10 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
     // Test events are strictly interleaved: each TestCase is followed by its TestResult.
     // We collect all TestCase events (including non-method metadata) and all TestResult events
     // in order, then pair them positionally to assign outcomes.
-    let mut all_test_cases: Vec<Option<models::TestCase>> = Vec::new();
-    let mut test_results: Vec<models::TestOutcome> = Vec::new();
+    // Each entry stores (Option<TestCase>, frame_timestamp) — timestamps are stored for ALL
+    // events including None placeholders to maintain positional alignment.
+    let mut all_test_cases: Vec<(Option<models::TestCase>, i64)> = Vec::new();
+    let mut test_results: Vec<(models::TestOutcome, i64, Option<models::FailureId>)> = Vec::new();
     let mut executor_names: HashMap<models::ExecutorId, String> = HashMap::new();
     let mut task_registration_summary: Option<events::TaskRegistrationSummaryEvent> = None;
     let mut basic_memory_stats: Option<events::BasicMemoryStatsEvent> = None;
@@ -177,16 +179,18 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         .executor_name
                         .clone()
                         .or_else(|| executor_names.get(&e.executor_id).cloned());
-                    all_test_cases.push(Some(models::TestCase {
+                    all_test_cases.push((Some(models::TestCase {
                         class_name: e.class_name.clone(),
                         method_name: e.method_name.clone(),
                         executor_name,
                         outcome: None,
-                    }));
+                        duration_ms: None,
+                        failure_id: None,
+                    }), frame.timestamp));
                 } else {
                     // Non-method event (class-level or executor-init): placeholder to
                     // keep positional alignment with TestResult events.
-                    all_test_cases.push(None);
+                    all_test_cases.push((None, frame.timestamp));
                 }
             }
             DecodedEvent::TestExecutorStarted(_) => {}
@@ -199,7 +203,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                 } else {
                     models::TestOutcome::Passed
                 };
-                test_results.push(outcome);
+                test_results.push((outcome, frame.timestamp, e.failure_id));
             }
             DecodedEvent::BuildCacheLocalLoadStarted(e) => {
                 cache_op_started.insert(
@@ -598,9 +602,14 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         .map(Some)
                         .chain(std::iter::repeat(None)),
                 )
-                .filter_map(|(tc, outcome)| {
+                .filter_map(|((tc, case_timestamp), result)| {
                     tc.map(|mut test_case| {
-                        test_case.outcome = outcome;
+                        if let Some((outcome, result_timestamp, failure_id)) = result {
+                            test_case.outcome = Some(outcome);
+                            let duration = result_timestamp - case_timestamp;
+                            test_case.duration_ms = if duration >= 0 { Some(duration) } else { None };
+                            test_case.failure_id = failure_id;
+                        }
                         test_case
                     })
                 })
@@ -729,6 +738,7 @@ mod tests {
                     id: 100,
                     failed: false,
                     skipped: false,
+                    failure_id: None,
                 }),
             ),
             (
@@ -747,6 +757,7 @@ mod tests {
                     id: 101,
                     failed: false,
                     skipped: false,
+                    failure_id: None,
                 }),
             ),
         ];
@@ -784,6 +795,7 @@ mod tests {
                     id: 100,
                     failed: false,
                     skipped: false,
+                    failure_id: None,
                 }),
             ),
             (
@@ -802,6 +814,7 @@ mod tests {
                     id: 200,
                     failed: true,
                     skipped: false,
+                    failure_id: None,
                 }),
             ),
         ];

--- a/build-scan/lib/src/assembly.rs
+++ b/build-scan/lib/src/assembly.rs
@@ -814,7 +814,7 @@ mod tests {
                     id: 200,
                     failed: true,
                     skipped: false,
-                    failure_id: None,
+                    failure_id: Some(models::FailureId::new(42)),
                 }),
             ),
         ];
@@ -830,6 +830,41 @@ mod tests {
             "expected Failed, got {:?}",
             payload.tests[1].outcome
         );
+        // Duration is computed from frame timestamp deltas
+        assert_eq!(payload.tests[0].duration_ms, Some(1), "testPass: 1001 - 1000 = 1ms");
+        assert_eq!(payload.tests[1].duration_ms, Some(1), "testFail: 2001 - 2000 = 1ms");
+        // failure_id is propagated from TestResult
+        assert!(payload.tests[0].failure_id.is_none(), "passing test should have no failure_id");
+        assert_eq!(payload.tests[1].failure_id, Some(models::FailureId::new(42)));
+    }
+
+    #[test]
+    fn test_assemble_test_duration_negative_is_none() {
+        // If result timestamp < case timestamp (shouldn't happen but defensive), duration is None
+        let events = vec![
+            (
+                frame(798, 5000),
+                DecodedEvent::TestCase(TestCaseEvent {
+                    executor_id: ExecutorId::new(1),
+                    class_name: "org.example.Test".into(),
+                    method_name: Some("test()".into()),
+                    executor_name: None,
+                }),
+            ),
+            (
+                frame(284, 4000), // timestamp before TestCase
+                DecodedEvent::TestResult(TestResultEvent {
+                    task: TaskId::new(1),
+                    id: 1,
+                    failed: false,
+                    skipped: false,
+                    failure_id: None,
+                }),
+            ),
+        ];
+        let payload = assemble(events);
+        assert_eq!(payload.tests.len(), 1);
+        assert_eq!(payload.tests[0].duration_ms, None, "negative duration should produce None");
     }
 
     #[test]

--- a/build-scan/lib/src/events/mod.rs
+++ b/build-scan/lib/src/events/mod.rs
@@ -478,6 +478,7 @@ pub struct TestResultEvent {
     pub id: i64,
     pub failed: bool,
     pub skipped: bool,
+    pub failure_id: Option<FailureId>,
 }
 
 #[derive(Debug, Clone)]

--- a/build-scan/lib/src/events/test_result.rs
+++ b/build-scan/lib/src/events/test_result.rs
@@ -1,5 +1,5 @@
 use error::ParseError;
-use models::TaskId;
+use models::{FailureId, TaskId};
 
 use super::{BodyDecoder, DecodedEvent, TestResultEvent};
 
@@ -43,17 +43,18 @@ impl BodyDecoder for TestResultDecoder {
         let skipped = kryo::is_field_present(flags as u16, 3);
 
         // Bit 4 indicates the presence of a failureId field in the wire format.
-        // We read-and-discard it because the bytes must be consumed to keep `pos`
-        // correct, but no downstream consumer currently uses failureId.
-        if kryo::is_field_present(flags as u16, 4) {
-            let _failure_id = kryo::read_task_id(body, &mut pos)?;
-        }
+        let failure_id = if kryo::is_field_present(flags as u16, 4) {
+            Some(FailureId::new(kryo::read_task_id(body, &mut pos)?))
+        } else {
+            None
+        };
 
         Ok(DecodedEvent::TestResult(TestResultEvent {
             task,
             id,
             failed,
             skipped,
+            failure_id,
         }))
     }
 }
@@ -78,6 +79,7 @@ mod tests {
             assert_eq!(e.id, 100);
             assert!(!e.failed);
             assert!(!e.skipped);
+            assert!(e.failure_id.is_none());
         } else {
             panic!("expected TestResult");
         }
@@ -140,6 +142,7 @@ mod tests {
         if let DecodedEvent::TestResult(e) = result {
             assert!(e.failed);
             assert!(!e.skipped);
+            assert_eq!(e.failure_id, Some(FailureId::new(999)));
         } else {
             panic!("expected TestResult");
         }

--- a/build-scan/lib/src/models.rs
+++ b/build-scan/lib/src/models.rs
@@ -393,4 +393,8 @@ pub struct TestCase {
     pub executor_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub outcome: Option<TestOutcome>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_id: Option<FailureId>,
 }

--- a/build-scan/server/db/migrations/src/BUILD.bazel
+++ b/build-scan/server/db/migrations/src/BUILD.bazel
@@ -11,6 +11,7 @@ rust_library(
         "sql/005_task_cache_detail.sql",
         "sql/006_task_cache_operations.sql",
         "sql/007_add_duration_ms_to_cache_operations.sql",
+        "sql/008_test_duration_and_failure.sql",
     ],
     visibility = ["//visibility:public"],
     deps = ["@crates//:sqlx"],

--- a/build-scan/server/db/migrations/src/lib.rs
+++ b/build-scan/server/db/migrations/src/lib.rs
@@ -65,6 +65,16 @@ pub static MIGRATOR: Migrator = Migrator {
             checksum: Cow::Borrowed(&[]),
             no_tx: false,
         },
+        Migration {
+            version: 8,
+            description: Cow::Borrowed("add test duration and failure details"),
+            migration_type: MigrationType::Simple,
+            sql: Cow::Borrowed(include_str!(
+                "sql/008_test_duration_and_failure.sql"
+            )),
+            checksum: Cow::Borrowed(&[]),
+            no_tx: false,
+        },
     ]),
     ignore_missing: false,
     locking: true,

--- a/build-scan/server/db/migrations/src/sql/008_test_duration_and_failure.sql
+++ b/build-scan/server/db/migrations/src/sql/008_test_duration_and_failure.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tests ADD COLUMN duration_ms INTEGER;
+ALTER TABLE tests ADD COLUMN failure_message TEXT;
+ALTER TABLE tests ADD COLUMN failure_stacktrace TEXT;

--- a/build-scan/server/db/src/lib.rs
+++ b/build-scan/server/db/src/lib.rs
@@ -73,6 +73,9 @@ struct TestRow {
     method_name: Option<String>,
     executor_name: Option<String>,
     outcome: Option<String>,
+    duration_ms: Option<i64>,
+    failure_message: Option<String>,
+    failure_stacktrace: Option<String>,
 }
 
 fn parse_datetime(s: &str) -> Result<chrono::DateTime<Utc>> {
@@ -248,6 +251,9 @@ impl TryFrom<TestRow> for domain::Test {
             method_name: row.method_name.map(domain::MethodName),
             executor_name: row.executor_name.map(domain::ExecutorName),
             outcome,
+            duration_ms: row.duration_ms,
+            failure_message: row.failure_message,
+            failure_stacktrace: row.failure_stacktrace,
         })
     }
 }
@@ -261,6 +267,9 @@ impl From<&domain::Test> for TestRow {
             method_name: test.method_name.as_ref().map(|m| m.0.clone()),
             executor_name: test.executor_name.as_ref().map(|e| e.0.clone()),
             outcome: test.outcome.map(|o| o.to_string()),
+            duration_ms: test.duration_ms,
+            failure_message: test.failure_message.clone(),
+            failure_stacktrace: test.failure_stacktrace.clone(),
         }
     }
 }
@@ -482,8 +491,8 @@ pub async fn insert_test<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite>>(
 ) -> Result<()> {
     let row = TestRow::from(test);
     sqlx::query(
-        "INSERT INTO tests (id, scan_id, class_name, method_name, executor_name, outcome) \
-         VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO tests (id, scan_id, class_name, method_name, executor_name, outcome, duration_ms, failure_message, failure_stacktrace) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&row.id)
     .bind(&row.scan_id)
@@ -491,6 +500,9 @@ pub async fn insert_test<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite>>(
     .bind(row.method_name.as_deref())
     .bind(row.executor_name.as_deref())
     .bind(row.outcome.as_deref())
+    .bind(row.duration_ms)
+    .bind(row.failure_message.as_deref())
+    .bind(row.failure_stacktrace.as_deref())
     .execute(executor)
     .await?;
     Ok(())
@@ -504,7 +516,7 @@ pub async fn list_tests(
 ) -> Result<Vec<domain::Test>> {
     let rows = if let Some(cursor) = after_id {
         sqlx::query_as::<_, TestRow>(
-            "SELECT id, scan_id, class_name, method_name, executor_name, outcome \
+            "SELECT id, scan_id, class_name, method_name, executor_name, outcome, duration_ms, failure_message, failure_stacktrace \
              FROM tests WHERE scan_id = ? AND id > ? ORDER BY id LIMIT ?",
         )
         .bind(scan_id)
@@ -514,7 +526,7 @@ pub async fn list_tests(
         .await?
     } else {
         sqlx::query_as::<_, TestRow>(
-            "SELECT id, scan_id, class_name, method_name, executor_name, outcome \
+            "SELECT id, scan_id, class_name, method_name, executor_name, outcome, duration_ms, failure_message, failure_stacktrace \
              FROM tests WHERE scan_id = ? ORDER BY id LIMIT ?",
         )
         .bind(scan_id)
@@ -537,13 +549,52 @@ pub async fn count_tests(pool: &SqlitePool, scan_id: &str) -> Result<i64> {
 
 pub async fn get_test(pool: &SqlitePool, id: &str) -> Result<Option<domain::Test>> {
     let row = sqlx::query_as::<_, TestRow>(
-        "SELECT id, scan_id, class_name, method_name, executor_name, outcome \
+        "SELECT id, scan_id, class_name, method_name, executor_name, outcome, duration_ms, failure_message, failure_stacktrace \
          FROM tests WHERE id = ?",
     )
     .bind(id)
     .fetch_optional(pool)
     .await?;
     row.map(domain::Test::try_from).transpose()
+}
+
+pub async fn test_summary(pool: &SqlitePool, scan_id: &str) -> Result<domain::TestSummary> {
+    #[derive(sqlx::FromRow)]
+    struct SummaryRow {
+        outcome: Option<String>,
+        count: i64,
+        total_duration_ms: Option<i64>,
+    }
+    let rows = sqlx::query_as::<_, SummaryRow>(
+        "SELECT outcome, COUNT(*) as count, SUM(duration_ms) as total_duration_ms \
+         FROM tests WHERE scan_id = ? GROUP BY outcome",
+    )
+    .bind(scan_id)
+    .fetch_all(pool)
+    .await?;
+
+    let mut passed = 0i64;
+    let mut failed = 0i64;
+    let mut skipped = 0i64;
+    let mut total_duration_ms: Option<i64> = None;
+    for row in rows {
+        let count = row.count;
+        if let Some(duration) = row.total_duration_ms {
+            *total_duration_ms.get_or_insert(0) += duration;
+        }
+        match row.outcome.as_deref() {
+            Some("Passed") => passed = count,
+            Some("Failed") => failed = count,
+            Some("Skipped") => skipped = count,
+            _ => {}
+        }
+    }
+    Ok(domain::TestSummary {
+        passed,
+        failed,
+        skipped,
+        total_duration_ms,
+    })
 }
 
 pub async fn insert_cache_operation<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite>>(

--- a/build-scan/server/domain/src/lib.rs
+++ b/build-scan/server/domain/src/lib.rs
@@ -396,6 +396,20 @@ pub struct Test {
     pub executor_name: Option<ExecutorName>,
     #[builder(setter(strip_option), default)]
     pub outcome: Option<TestOutcome>,
+    #[builder(setter(strip_option), default)]
+    pub duration_ms: Option<i64>,
+    #[builder(setter(strip_option), default)]
+    pub failure_message: Option<String>,
+    #[builder(setter(strip_option), default)]
+    pub failure_stacktrace: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TestSummary {
+    pub passed: i64,
+    pub failed: i64,
+    pub skipped: i64,
+    pub total_duration_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone)]

--- a/build-scan/server/graphql/src/lib.rs
+++ b/build-scan/server/graphql/src/lib.rs
@@ -390,8 +390,14 @@ impl Test {
         self.test.outcome.map(|o| o.to_string())
     }
 
-    fn duration_ms(&self) -> Option<i32> {
-        self.test.duration_ms.map(|d| d as i32)
+    fn duration_ms(&self) -> FieldResult<Option<i32>> {
+        self.test
+            .duration_ms
+            .map(|d| {
+                i32::try_from(d)
+                    .map_err(|_| FieldError::from("duration_ms exceeds GraphQL Int range"))
+            })
+            .transpose()
     }
 
     fn failure_message(&self) -> Option<&str> {
@@ -425,8 +431,14 @@ impl TestSummary {
         self.summary.skipped as i32
     }
 
-    fn total_duration_ms(&self) -> Option<i32> {
-        self.summary.total_duration_ms.map(|d| d as i32)
+    fn total_duration_ms(&self) -> FieldResult<Option<i32>> {
+        self.summary
+            .total_duration_ms
+            .map(|d| {
+                i32::try_from(d)
+                    .map_err(|_| FieldError::from("total_duration_ms exceeds GraphQL Int range"))
+            })
+            .transpose()
     }
 }
 

--- a/build-scan/server/graphql/src/lib.rs
+++ b/build-scan/server/graphql/src/lib.rs
@@ -168,6 +168,15 @@ impl BuildScan {
         Ok(count)
     }
 
+    async fn test_summary(&self, context: &Context) -> FieldResult<TestSummary> {
+        let summary = context
+            .service
+            .test_summary(&self.scan.id.0.to_string())
+            .await
+            .map_err(|e| FieldError::from(e.to_string()))?;
+        Ok(TestSummary { summary })
+    }
+
     async fn tests(
         &self,
         context: &Context,
@@ -379,6 +388,45 @@ impl Test {
 
     fn outcome(&self) -> Option<String> {
         self.test.outcome.map(|o| o.to_string())
+    }
+
+    fn duration_ms(&self) -> Option<i32> {
+        self.test.duration_ms.map(|d| d as i32)
+    }
+
+    fn failure_message(&self) -> Option<&str> {
+        self.test.failure_message.as_deref()
+    }
+
+    fn failure_stacktrace(&self) -> Option<&str> {
+        self.test.failure_stacktrace.as_deref()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TestSummary type
+// ---------------------------------------------------------------------------
+
+pub struct TestSummary {
+    pub summary: domain::TestSummary,
+}
+
+#[graphql_object(context = Context)]
+impl TestSummary {
+    fn passed(&self) -> i32 {
+        self.summary.passed as i32
+    }
+
+    fn failed(&self) -> i32 {
+        self.summary.failed as i32
+    }
+
+    fn skipped(&self) -> i32 {
+        self.summary.skipped as i32
+    }
+
+    fn total_duration_ms(&self) -> Option<i32> {
+        self.summary.total_duration_ms.map(|d| d as i32)
     }
 }
 

--- a/build-scan/server/service/src/lib.rs
+++ b/build-scan/server/service/src/lib.rs
@@ -250,6 +250,9 @@ impl BuildScanService {
                     if let Some(o) = &test.outcome {
                         test_builder.outcome(map_test_outcome(o));
                     }
+                    if let Some(d) = test.duration_ms {
+                        test_builder.duration_ms(d);
+                    }
 
                     let domain_test = test_builder
                         .build()
@@ -315,6 +318,10 @@ impl BuildScanService {
 
     pub async fn count_tests(&self, scan_id: &str) -> Result<i64> {
         db::count_tests(&self.pool, scan_id).await
+    }
+
+    pub async fn test_summary(&self, scan_id: &str) -> Result<domain::TestSummary> {
+        db::test_summary(&self.pool, scan_id).await
     }
 
     pub async fn get_test(&self, id: &str) -> Result<Option<domain::Test>> {

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/aq4s5j9yjv6rhzd6r0cnkrq33xn2qbmm-mesa-26.0.3

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/aq4s5j9yjv6rhzd6r0cnkrq33xn2qbmm-mesa-26.0.3


### PR DESCRIPTION
## Summary
- Capture per-test duration (computed from frame timestamp deltas between TestCase/TestResult events) across the full stack
- Capture `failure_id` from wire 284 (previously read-and-discarded) using `FailureId` newtype for future ExceptionTree correlation
- Add scan-level test summary stats (passed/failed/skipped counts + total duration) as a GraphQL field
- Add Duration column, expandable failure detail rows, and summary badges to the Angular frontend

## Changes
- **Parser**: `test_result.rs` captures `failure_id`, `assembly.rs` computes `duration_ms` from frame timestamp deltas
- **Server**: New DB migration (008), `TestSummary` domain model, `test_summary()` aggregate query, GraphQL `durationMs`/`failureMessage`/`failureStacktrace` fields + `TestSummary` type
- **Frontend**: Duration column, clickable failed test rows with expandable stack trace panel, summary stat badges

## Follow-up (Phase 2)
- ExceptionTree wire format reverse-engineering to populate `failure_message`/`failure_stacktrace` columns (infrastructure is ready)

## Test plan
- [x] All 9 Rust tests pass (`bazelisk test //build-scan/...`)
- [x] Angular tests pass with updated assertions for new Duration column and summary stats
- [x] Build succeeds for all targets (`bazelisk build //build-scan/... //angular/...`)
- [ ] E2E: dogfooding with intentionally failing Gradle test shows duration + summary in UI