### PR TITLE
chore: add JDK 21 and Chrome libraries to nix dev shell

### DIFF
--- a/angular/CLAUDE.md
+++ b/angular/CLAUDE.md
@@ -79,10 +79,12 @@ JSON.stringify({
   timeline: document.querySelector("app-task-timeline") !== null,
   cacheBreakdown: document.querySelector("app-cache-breakdown") !== null,
   tasksTable: document.querySelector("app-tasks-table") !== null,
-  testsTable: document.querySelector("app-tests-table") !== null
+  testsTable: document.querySelector("app-tests-table") !== null,
+  testDurationColumn: Array.from(document.querySelectorAll("th")).some(h => h.textContent.trim() === "Duration"),
+  testSummaryBadges: document.querySelectorAll(".badge-lg").length
 })
 EOF
-# Expected: all true
+# Expected: all true, testSummaryBadges >= 3
 
 # 4. Take a screenshot (use dark theme for visibility in headless)
 agent-browser eval 'document.documentElement.setAttribute("data-theme", "dark")'
@@ -91,6 +93,7 @@ agent-browser screenshot --full /tmp/scan-detail.png
 # 5. Clean up
 agent-browser close
 ```
+
 
 ## Adding npm Dependencies
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775525641,
-        "narHash": "sha256-rM50ZJFuc9ePeWX7mgkX3jyqIlJoAdhyGsz5d2xhaTk=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc72a9d2282085d97d5a2cc8e7103a68ed4de188",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,37 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          # Shared libraries needed by agent-browser's bundled Chrome
+          chromeLibs = pkgs.lib.makeLibraryPath [
+            pkgs.alsa-lib
+            pkgs.at-spi2-atk
+            pkgs.atk
+            pkgs.cairo
+            pkgs.cups
+            pkgs.dbus
+            pkgs.expat
+            pkgs.glib
+            pkgs.gtk3
+            pkgs.libdrm
+            pkgs.libgbm
+            pkgs.libglvnd
+            pkgs.libX11
+            pkgs.libXcomposite
+            pkgs.libXdamage
+            pkgs.libXext
+            pkgs.libXfixes
+            pkgs.libxcb
+            pkgs.libxkbcommon
+            pkgs.libXrandr
+            pkgs.mesa
+            pkgs.nspr
+            pkgs.nss
+            pkgs.pango
+            pkgs.pipewire
+            pkgs.stdenv.cc.cc.lib
+            pkgs.systemd
+            pkgs.zlib
+          ];
         in
         {
           default = pkgs.mkShell {
@@ -28,18 +59,42 @@
               pkgs.bazelisk
               pkgs.gcc
               pkgs.gradle
+              pkgs.jdk21
               pkgs.pre-commit
             ];
 
             # Linux: set NIX_LD so bazelisk can run downloaded Bazel binaries
             # On NixOS, this additionally requires `programs.nix-ld.enable = true`
-            env = pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            env = {
+              JAVA_HOME = "${pkgs.jdk21}";
+            } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
               NIX_LD = pkgs.stdenv.cc.bintools.dynamicLinker;
-              NIX_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
-                pkgs.stdenv.cc.cc.lib
-                pkgs.zlib
-              ];
+              NIX_LD_LIBRARY_PATH = chromeLibs;
             };
+
+            shellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+              # Wrap agent-browser's bundled Chrome so it can find shared libraries.
+              # agent-browser strips LD_LIBRARY_PATH when spawning Chrome, so we
+              # inject it via a wrapper script with hardcoded paths.
+              _wrap_agent_browser_chrome() {
+                local chrome_dir="$HOME/.agent-browser/browsers"
+                if [[ -d "$chrome_dir" ]]; then
+                  for dir in "$chrome_dir"/chrome-*; do
+                    local chrome="$dir/chrome"
+                    if [[ -f "$chrome" ]] && ! head -1 "$chrome" 2>/dev/null | grep -q "^#!"; then
+                      mv "$chrome" "$chrome.orig"
+                      cat > "$chrome" << WRAPPER
+              #!/usr/bin/env bash
+              export LD_LIBRARY_PATH="${chromeLibs}"
+              exec "\$(dirname "\$0")/chrome.orig" "\$@"
+              WRAPPER
+                      chmod +x "$chrome"
+                    fi
+                  done
+                fi
+              }
+              _wrap_agent_browser_chrome
+            '';
           };
         }
       );


### PR DESCRIPTION
## Summary
- Add `jdk21` with `JAVA_HOME` for running the Gradle dogfooding project
- Add Chrome shared libraries to `NIX_LD_LIBRARY_PATH` and `LD_LIBRARY_PATH` for agent-browser's bundled Chrome on NixOS
- Add `shellHook` that wraps agent-browser's Chrome binary with `LD_LIBRARY_PATH` (agent-browser strips env vars when spawning Chrome)
- Update agent-browser visual verification checks for test results UI (Duration column, summary badges)

## Test plan
- [x] `nix flake check` passes
- [x] `direnv exec . java -version` shows JDK 21
- [x] `direnv exec . agent-browser open <url>` launches Chrome successfully
- [x] Visual verification confirms UI elements render correctly