### PR TITLE
build: Enable Renovate nix manager and lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":approveMajorUpdates", ":automergeAll"],
+  "nix": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
   "packageRules": [
     {
       "matchManagers": ["cargo"],


### PR DESCRIPTION
## Summary
- Enable Renovate's `nix` manager so updates to the `nixpkgs` input in `flake.nix` are proposed automatically.
- Enable weekly `lockFileMaintenance` so `flake.lock` (and other lock files) stay fresh even when no top-level manifest changes.