### PR TITLE
refactor: Use newtypes for durations, timestamps, sizes, and counts

### DIFF
--- a/build-scan/lib/src/assembly.rs
+++ b/build-scan/lib/src/assembly.rs
@@ -474,14 +474,16 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                     .and_then(|f| f.caching_disabled_explanation.clone()),
                 origin_build_cache_key: fin.and_then(|f| f.origin_build_cache_key.clone()),
                 actionable: fin.and_then(|f| f.actionable),
-                started_at,
-                finished_at,
-                duration_ms,
+                started_at: started_at.map(models::Timestamp::new),
+                finished_at: finished_at.map(models::Timestamp::new),
+                duration_ms: duration_ms.map(models::Duration::new),
                 inputs,
                 up_to_date_messages: fin.and_then(|f| f.up_to_date_messages.clone()),
                 origin_build_invocation_id: fin
                     .and_then(|f| f.origin_build_invocation_id.clone()),
-                origin_execution_time: fin.and_then(|f| f.origin_execution_time),
+                origin_execution_time: fin
+                    .and_then(|f| f.origin_execution_time)
+                    .map(models::Duration::new),
                 cache_operations: Vec::new(),
             }
         })
@@ -506,12 +508,15 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
             stored: finished.and_then(|f| f.stored),
             archive_size: finished
                 .and_then(|f| f.archive_size)
-                .or(*started_archive_size),
-            archive_entry_count: finished.and_then(|f| f.archive_entry_count),
+                .or(*started_archive_size)
+                .map(models::ArchiveSize::new),
+            archive_entry_count: finished
+                .and_then(|f| f.archive_entry_count)
+                .map(models::EntryCount::new),
             failure_id: finished.and_then(|f| f.failure_id),
             remote_cache_location: finished.and_then(|f| f.remote_cache_location.clone()),
             rejected_reason: finished.and_then(|f| f.rejected_reason),
-            duration_ms,
+            duration_ms: duration_ms.map(models::Duration::new),
         };
         task_cache_ops
             .entry(TaskId::new(*work_id))
@@ -528,7 +533,10 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
 
     let mut raw_events: Vec<RawEventSummary> = raw_counts
         .into_iter()
-        .map(|(wire_id, count)| RawEventSummary { wire_id, count })
+        .map(|(wire_id, count)| RawEventSummary {
+            wire_id,
+            count: models::EventCount::new(count),
+        })
         .collect();
     raw_events.sort_by_key(|r| r.wire_id);
 
@@ -607,7 +615,11 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         if let Some((outcome, result_timestamp, failure_id)) = result {
                             test_case.outcome = Some(outcome);
                             let duration = result_timestamp - case_timestamp;
-                            test_case.duration_ms = if duration >= 0 { Some(duration) } else { None };
+                            test_case.duration_ms = if duration >= 0 {
+                                Some(models::Duration::new(duration))
+                            } else {
+                                None
+                            };
                             test_case.failure_id = failure_id;
                         }
                         test_case
@@ -831,8 +843,16 @@ mod tests {
             payload.tests[1].outcome
         );
         // Duration is computed from frame timestamp deltas
-        assert_eq!(payload.tests[0].duration_ms, Some(1), "testPass: 1001 - 1000 = 1ms");
-        assert_eq!(payload.tests[1].duration_ms, Some(1), "testFail: 2001 - 2000 = 1ms");
+        assert_eq!(
+            payload.tests[0].duration_ms,
+            Some(models::Duration::new(1)),
+            "testPass: 1001 - 1000 = 1ms"
+        );
+        assert_eq!(
+            payload.tests[1].duration_ms,
+            Some(models::Duration::new(1)),
+            "testFail: 2001 - 2000 = 1ms"
+        );
         // failure_id is propagated from TestResult
         assert!(payload.tests[0].failure_id.is_none(), "passing test should have no failure_id");
         assert_eq!(payload.tests[1].failure_id, Some(models::FailureId::new(42)));
@@ -909,9 +929,9 @@ mod tests {
         assert_eq!(payload.tasks.len(), 1);
         let task = &payload.tasks[0];
         assert_eq!(task.task_path, ":app:build");
-        assert_eq!(task.started_at, Some(2000));
-        assert_eq!(task.finished_at, Some(3000));
-        assert_eq!(task.duration_ms, Some(1000));
+        assert_eq!(task.started_at, Some(models::Timestamp::new(2000)));
+        assert_eq!(task.finished_at, Some(models::Timestamp::new(3000)));
+        assert_eq!(task.duration_ms, Some(models::Duration::new(1000)));
         assert!(matches!(task.outcome, Some(TaskOutcome::Success)));
         assert!(task.inputs.is_none());
         assert!(task.cache_operations.is_empty());
@@ -993,9 +1013,9 @@ mod tests {
         assert_eq!(op.operation_type, CacheOperationType::LocalLoad);
         assert_eq!(op.cache_key.as_deref(), Some("abc123"));
         assert_eq!(op.hit, Some(true));
-        assert_eq!(op.archive_size, Some(8192));
+        assert_eq!(op.archive_size, Some(models::ArchiveSize::new(8192)));
         assert_eq!(op.failure_id, None);
-        assert_eq!(op.duration_ms, Some(500)); // 3000 - 2500
+        assert_eq!(op.duration_ms, Some(models::Duration::new(500))); // 3000 - 2500
         assert_eq!(op.stored, None);
         assert_eq!(op.remote_cache_location, None);
         assert_eq!(op.rejected_reason, None);

--- a/build-scan/lib/src/events/basic_memory_stats.rs
+++ b/build-scan/lib/src/events/basic_memory_stats.rs
@@ -12,19 +12,25 @@ impl BodyDecoder for BasicMemoryStatsDecoder {
         let mut table = kryo::StringInternTable::new();
 
         let free = if kryo::is_field_present(flags as u16, 0) {
-            Some(kryo::read_kryo_long_unsigned(body, &mut pos)?)
+            Some(models::MemoryBytes::new(kryo::read_kryo_long_unsigned(
+                body, &mut pos,
+            )?))
         } else {
             None
         };
 
         let total = if kryo::is_field_present(flags as u16, 1) {
-            Some(kryo::read_kryo_long_unsigned(body, &mut pos)?)
+            Some(models::MemoryBytes::new(kryo::read_kryo_long_unsigned(
+                body, &mut pos,
+            )?))
         } else {
             None
         };
 
         let max = if kryo::is_field_present(flags as u16, 2) {
-            Some(kryo::read_kryo_long_unsigned(body, &mut pos)?)
+            Some(models::MemoryBytes::new(kryo::read_kryo_long_unsigned(
+                body, &mut pos,
+            )?))
         } else {
             None
         };
@@ -41,7 +47,9 @@ impl BodyDecoder for BasicMemoryStatsDecoder {
         };
 
         let gc_time = if kryo::is_field_present(flags as u16, 4) {
-            Some(kryo::read_kryo_long_unsigned(body, &mut pos)?)
+            Some(models::Duration::new(kryo::read_kryo_long_unsigned(
+                body, &mut pos,
+            )?))
         } else {
             None
         };
@@ -73,25 +81,33 @@ fn decode_memory_pool_snapshot(
     let heap = kryo::is_field_present(flags as u16, 1);
 
     let init = if kryo::is_field_present(flags as u16, 2) {
-        Some(kryo::read_kryo_long_unsigned(body, pos)?)
+        Some(models::MemoryBytes::new(kryo::read_kryo_long_unsigned(
+            body, pos,
+        )?))
     } else {
         None
     };
 
     let used = if kryo::is_field_present(flags as u16, 3) {
-        Some(kryo::read_kryo_long_unsigned(body, pos)?)
+        Some(models::MemoryBytes::new(kryo::read_kryo_long_unsigned(
+            body, pos,
+        )?))
     } else {
         None
     };
 
     let committed = if kryo::is_field_present(flags as u16, 4) {
-        Some(kryo::read_kryo_long_unsigned(body, pos)?)
+        Some(models::MemoryBytes::new(kryo::read_kryo_long_unsigned(
+            body, pos,
+        )?))
     } else {
         None
     };
 
     let max = if kryo::is_field_present(flags as u16, 5) {
-        Some(kryo::read_kryo_long_unsigned(body, pos)?)
+        Some(models::MemoryBytes::new(kryo::read_kryo_long_unsigned(
+            body, pos,
+        )?))
     } else {
         None
     };
@@ -144,9 +160,9 @@ mod tests {
         let decoder = BasicMemoryStatsDecoder;
         let result = decoder.decode(&data).unwrap();
         if let DecodedEvent::BasicMemoryStats(e) = result {
-            assert_eq!(e.free, Some(100));
-            assert_eq!(e.total, Some(512));
-            assert_eq!(e.max, Some(1024));
+            assert_eq!(e.free, Some(models::MemoryBytes::new(100)));
+            assert_eq!(e.total, Some(models::MemoryBytes::new(512)));
+            assert_eq!(e.max, Some(models::MemoryBytes::new(1024)));
             assert!(e.peak_snapshots.is_empty());
             assert_eq!(e.gc_time, None);
         } else {
@@ -237,27 +253,27 @@ mod tests {
         let decoder = BasicMemoryStatsDecoder;
         let result = decoder.decode(&data).unwrap();
         if let DecodedEvent::BasicMemoryStats(e) = result {
-            assert_eq!(e.free, Some(100));
-            assert_eq!(e.total, Some(512));
-            assert_eq!(e.max, Some(1024));
-            assert_eq!(e.gc_time, Some(42));
+            assert_eq!(e.free, Some(models::MemoryBytes::new(100)));
+            assert_eq!(e.total, Some(models::MemoryBytes::new(512)));
+            assert_eq!(e.max, Some(models::MemoryBytes::new(1024)));
+            assert_eq!(e.gc_time, Some(models::Duration::new(42)));
             assert_eq!(e.peak_snapshots.len(), 2);
 
             let s1 = &e.peak_snapshots[0];
             assert_eq!(s1.name, Some("Eden Space".to_string()));
             assert!(s1.heap);
-            assert_eq!(s1.init, Some(50));
-            assert_eq!(s1.used, Some(200));
-            assert_eq!(s1.committed, Some(256));
-            assert_eq!(s1.max, Some(512));
+            assert_eq!(s1.init, Some(models::MemoryBytes::new(50)));
+            assert_eq!(s1.used, Some(models::MemoryBytes::new(200)));
+            assert_eq!(s1.committed, Some(models::MemoryBytes::new(256)));
+            assert_eq!(s1.max, Some(models::MemoryBytes::new(512)));
 
             let s2 = &e.peak_snapshots[1];
             assert_eq!(s2.name, Some("Eden Space".to_string())); // back-ref
             assert!(!s2.heap);
-            assert_eq!(s2.init, Some(10));
-            assert_eq!(s2.used, Some(30));
-            assert_eq!(s2.committed, Some(64));
-            assert_eq!(s2.max, Some(128));
+            assert_eq!(s2.init, Some(models::MemoryBytes::new(10)));
+            assert_eq!(s2.used, Some(models::MemoryBytes::new(30)));
+            assert_eq!(s2.committed, Some(models::MemoryBytes::new(64)));
+            assert_eq!(s2.max, Some(models::MemoryBytes::new(128)));
         } else {
             panic!("expected BasicMemoryStats");
         }

--- a/build-scan/lib/src/events/hardware.rs
+++ b/build-scan/lib/src/events/hardware.rs
@@ -10,7 +10,9 @@ impl BodyDecoder for HardwareDecoder {
         let mut pos = 0;
         let num_processors = kryo::read_positive_varint_i32(body, &mut pos)?;
 
-        Ok(DecodedEvent::Hardware(HardwareEvent { num_processors }))
+        Ok(DecodedEvent::Hardware(HardwareEvent {
+            num_processors: models::ProcessorCount::new(num_processors),
+        }))
     }
 }
 
@@ -24,7 +26,7 @@ mod tests {
         let decoder = HardwareDecoder;
         let result = decoder.decode(&data).unwrap();
         if let DecodedEvent::Hardware(e) = result {
-            assert_eq!(e.num_processors, 8);
+            assert_eq!(e.num_processors, models::ProcessorCount::new(8));
         } else {
             panic!("expected Hardware");
         }

--- a/build-scan/lib/src/events/mod.rs
+++ b/build-scan/lib/src/events/mod.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use error::ParseError;
-use models::{ExecutorId, FailureId, FileRefId, TaskId, TransformId};
+use models::{
+    Duration, ExecutorId, FailureId, FileRefId, MemoryBytes, ProcessorCount, TaskCount, TaskId,
+    TransformId,
+};
 
 pub mod basic_memory_stats;
 pub mod build_agent;
@@ -338,7 +341,7 @@ pub struct FileRefRootEntry {
 
 #[derive(Debug, Clone)]
 pub struct HardwareEvent {
-    pub num_processors: i32,
+    pub num_processors: ProcessorCount,
 }
 
 #[derive(Debug, Clone)]
@@ -385,26 +388,26 @@ pub struct ScopeIdsEvent {
 
 #[derive(Debug, Clone)]
 pub struct TaskRegistrationSummaryEvent {
-    pub task_count: i32,
+    pub task_count: TaskCount,
 }
 
 #[derive(Debug, Clone)]
 pub struct BasicMemoryStatsEvent {
-    pub free: Option<i64>,
-    pub total: Option<i64>,
-    pub max: Option<i64>,
+    pub free: Option<MemoryBytes>,
+    pub total: Option<MemoryBytes>,
+    pub max: Option<MemoryBytes>,
     pub peak_snapshots: Vec<MemoryPoolSnapshotEvent>,
-    pub gc_time: Option<i64>,
+    pub gc_time: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]
 pub struct MemoryPoolSnapshotEvent {
     pub name: Option<String>,
     pub heap: bool,
-    pub init: Option<i64>,
-    pub used: Option<i64>,
-    pub committed: Option<i64>,
-    pub max: Option<i64>,
+    pub init: Option<MemoryBytes>,
+    pub used: Option<MemoryBytes>,
+    pub committed: Option<MemoryBytes>,
+    pub max: Option<MemoryBytes>,
 }
 
 #[derive(Debug, Clone)]

--- a/build-scan/lib/src/events/task_registration_summary.rs
+++ b/build-scan/lib/src/events/task_registration_summary.rs
@@ -11,7 +11,9 @@ impl BodyDecoder for TaskRegistrationSummaryDecoder {
         let task_count = kryo::read_positive_varint_i32(body, &mut pos)?;
 
         Ok(DecodedEvent::TaskRegistrationSummary(
-            TaskRegistrationSummaryEvent { task_count },
+            TaskRegistrationSummaryEvent {
+                task_count: models::TaskCount::new(task_count),
+            },
         ))
     }
 }
@@ -26,7 +28,7 @@ mod tests {
         let decoder = TaskRegistrationSummaryDecoder;
         let result = decoder.decode(&data).unwrap();
         if let DecodedEvent::TaskRegistrationSummary(e) = result {
-            assert_eq!(e.task_count, 10);
+            assert_eq!(e.task_count, models::TaskCount::new(10));
         } else {
             panic!("expected TaskRegistrationSummary");
         }

--- a/build-scan/lib/src/models.rs
+++ b/build-scan/lib/src/models.rs
@@ -50,6 +50,168 @@ impl FileRefId {
     }
 }
 
+// === Domain newtypes for numeric values ===
+
+/// Duration in milliseconds
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Duration(pub(crate) i64);
+
+impl Duration {
+    pub fn new(ms: i64) -> Self {
+        Self(ms)
+    }
+    pub fn as_i64(&self) -> i64 {
+        self.0
+    }
+}
+
+impl From<i64> for Duration {
+    fn from(v: i64) -> Self {
+        Self(v)
+    }
+}
+
+/// Epoch milliseconds — a point in time
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Timestamp(pub(crate) i64);
+
+impl Timestamp {
+    pub fn new(ms: i64) -> Self {
+        Self(ms)
+    }
+    pub fn as_i64(&self) -> i64 {
+        self.0
+    }
+}
+
+impl From<i64> for Timestamp {
+    fn from(v: i64) -> Self {
+        Self(v)
+    }
+}
+
+/// Cache archive size in bytes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ArchiveSize(pub(crate) i64);
+
+impl ArchiveSize {
+    pub fn new(bytes: i64) -> Self {
+        Self(bytes)
+    }
+    pub fn as_i64(&self) -> i64 {
+        self.0
+    }
+}
+
+impl From<i64> for ArchiveSize {
+    fn from(v: i64) -> Self {
+        Self(v)
+    }
+}
+
+/// Memory pool bytes (free/total/max/init/used/committed)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MemoryBytes(pub(crate) i64);
+
+impl MemoryBytes {
+    pub fn new(bytes: i64) -> Self {
+        Self(bytes)
+    }
+    pub fn as_i64(&self) -> i64 {
+        self.0
+    }
+}
+
+impl From<i64> for MemoryBytes {
+    fn from(v: i64) -> Self {
+        Self(v)
+    }
+}
+
+/// Cache archive entry count
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EntryCount(pub(crate) i64);
+
+impl EntryCount {
+    pub fn new(count: i64) -> Self {
+        Self(count)
+    }
+    pub fn as_i64(&self) -> i64 {
+        self.0
+    }
+}
+
+impl From<i64> for EntryCount {
+    fn from(v: i64) -> Self {
+        Self(v)
+    }
+}
+
+/// Number of tasks registered in the build
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TaskCount(pub(crate) i32);
+
+impl TaskCount {
+    pub fn new(count: i32) -> Self {
+        Self(count)
+    }
+    pub fn as_i32(&self) -> i32 {
+        self.0
+    }
+}
+
+impl From<i32> for TaskCount {
+    fn from(v: i32) -> Self {
+        Self(v)
+    }
+}
+
+/// Number of CPU processors
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ProcessorCount(pub(crate) i32);
+
+impl ProcessorCount {
+    pub fn new(count: i32) -> Self {
+        Self(count)
+    }
+    pub fn as_i32(&self) -> i32 {
+        self.0
+    }
+}
+
+impl From<i32> for ProcessorCount {
+    fn from(v: i32) -> Self {
+        Self(v)
+    }
+}
+
+/// Generic event tally in a raw event summary
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EventCount(pub(crate) usize);
+
+impl EventCount {
+    pub fn new(count: usize) -> Self {
+        Self(count)
+    }
+    pub fn as_usize(&self) -> usize {
+        self.0
+    }
+}
+
+impl From<usize> for EventCount {
+    fn from(v: usize) -> Self {
+        Self(v)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BuildScanPayload {
     pub tasks: Vec<Task>,
@@ -100,9 +262,9 @@ pub struct CacheOperation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stored: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub archive_size: Option<i64>,
+    pub archive_size: Option<ArchiveSize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub archive_entry_count: Option<i64>,
+    pub archive_entry_count: Option<EntryCount>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -110,7 +272,7 @@ pub struct CacheOperation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rejected_reason: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<i64>,
+    pub duration_ms: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,11 +295,11 @@ pub struct Task {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actionable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub started_at: Option<i64>,
+    pub started_at: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub finished_at: Option<i64>,
+    pub finished_at: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<i64>,
+    pub duration_ms: Option<Duration>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inputs: Option<TaskInputs>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -145,7 +307,7 @@ pub struct Task {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub origin_build_invocation_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub origin_execution_time: Option<i64>,
+    pub origin_execution_time: Option<Duration>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cache_operations: Vec<CacheOperation>,
 }
@@ -179,7 +341,7 @@ impl TaskOutcome {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RawEventSummary {
     pub wire_id: u16,
-    pub count: usize,
+    pub count: EventCount,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -280,21 +442,21 @@ pub struct TransformExecutionRequestData {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskRegistrationSummaryData {
-    pub task_count: i32,
+    pub task_count: TaskCount,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BasicMemoryStatsData {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub free: Option<i64>,
+    pub free: Option<MemoryBytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total: Option<i64>,
+    pub total: Option<MemoryBytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max: Option<i64>,
+    pub max: Option<MemoryBytes>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub peak_snapshots: Vec<MemoryPoolSnapshotData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gc_time: Option<i64>,
+    pub gc_time: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -303,13 +465,13 @@ pub struct MemoryPoolSnapshotData {
     pub name: Option<String>,
     pub heap: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub init: Option<i64>,
+    pub init: Option<MemoryBytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub used: Option<i64>,
+    pub used: Option<MemoryBytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub committed: Option<i64>,
+    pub committed: Option<MemoryBytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max: Option<i64>,
+    pub max: Option<MemoryBytes>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -394,7 +556,7 @@ pub struct TestCase {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub outcome: Option<TestOutcome>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<i64>,
+    pub duration_ms: Option<Duration>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_id: Option<FailureId>,
 }

--- a/build-scan/server/db/src/lib.rs
+++ b/build-scan/server/db/src/lib.rs
@@ -251,7 +251,7 @@ impl TryFrom<TestRow> for domain::Test {
             method_name: row.method_name.map(domain::MethodName),
             executor_name: row.executor_name.map(domain::ExecutorName),
             outcome,
-            duration_ms: row.duration_ms,
+            duration_ms: row.duration_ms.map(domain::Duration),
             failure_message: row.failure_message,
             failure_stacktrace: row.failure_stacktrace,
         })
@@ -267,7 +267,7 @@ impl From<&domain::Test> for TestRow {
             method_name: test.method_name.as_ref().map(|m| m.0.clone()),
             executor_name: test.executor_name.as_ref().map(|e| e.0.clone()),
             outcome: test.outcome.map(|o| o.to_string()),
-            duration_ms: test.duration_ms,
+            duration_ms: test.duration_ms.map(|d| d.0),
             failure_message: test.failure_message.clone(),
             failure_stacktrace: test.failure_stacktrace.clone(),
         }
@@ -294,9 +294,9 @@ impl TryFrom<CacheOperationRow> for domain::CacheOperation {
             task_id,
             operation_type,
             succeeded: row.succeeded != 0,
-            archive_size: row.archive_size,
+            archive_size: row.archive_size.map(domain::ArchiveSize),
             cache_key: row.cache_key,
-            duration_ms: row.duration_ms,
+            duration_ms: row.duration_ms.map(domain::Duration),
         })
     }
 }
@@ -308,9 +308,9 @@ impl From<&domain::CacheOperation> for CacheOperationRow {
             task_id: op.task_id.0.to_string(),
             operation_type: op.operation_type.to_string(),
             succeeded: if op.succeeded { 1 } else { 0 },
-            archive_size: op.archive_size,
+            archive_size: op.archive_size.map(|s| s.0),
             cache_key: op.cache_key.clone(),
-            duration_ms: op.duration_ms,
+            duration_ms: op.duration_ms.map(|d| d.0),
         }
     }
 }
@@ -590,10 +590,10 @@ pub async fn test_summary(pool: &SqlitePool, scan_id: &str) -> Result<domain::Te
         }
     }
     Ok(domain::TestSummary {
-        passed,
-        failed,
-        skipped,
-        total_duration_ms,
+        passed: domain::TestCount(passed),
+        failed: domain::TestCount(failed),
+        skipped: domain::TestCount(skipped),
+        total_duration_ms: total_duration_ms.map(domain::Duration),
     })
 }
 

--- a/build-scan/server/domain/src/lib.rs
+++ b/build-scan/server/domain/src/lib.rs
@@ -85,6 +85,14 @@ pub struct Timestamp(pub i64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Duration(pub i64);
 
+/// Cache archive size in bytes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ArchiveSize(pub i64);
+
+/// Test count (passed/failed/skipped totals in a test summary)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TestCount(pub i64);
+
 // === From impls for newtype wrappers (enables derive_builder setter(into)) ===
 
 impl From<Uuid> for BuildScanId {
@@ -178,6 +186,16 @@ impl From<i64> for Timestamp {
     }
 }
 impl From<i64> for Duration {
+    fn from(v: i64) -> Self {
+        Self(v)
+    }
+}
+impl From<i64> for ArchiveSize {
+    fn from(v: i64) -> Self {
+        Self(v)
+    }
+}
+impl From<i64> for TestCount {
     fn from(v: i64) -> Self {
         Self(v)
     }
@@ -397,7 +415,7 @@ pub struct Test {
     #[builder(setter(strip_option), default)]
     pub outcome: Option<TestOutcome>,
     #[builder(setter(strip_option), default)]
-    pub duration_ms: Option<i64>,
+    pub duration_ms: Option<Duration>,
     #[builder(setter(strip_option), default)]
     pub failure_message: Option<String>,
     #[builder(setter(strip_option), default)]
@@ -406,10 +424,10 @@ pub struct Test {
 
 #[derive(Debug, Clone)]
 pub struct TestSummary {
-    pub passed: i64,
-    pub failed: i64,
-    pub skipped: i64,
-    pub total_duration_ms: Option<i64>,
+    pub passed: TestCount,
+    pub failed: TestCount,
+    pub skipped: TestCount,
+    pub total_duration_ms: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]
@@ -418,7 +436,7 @@ pub struct CacheOperation {
     pub task_id: TaskId,
     pub operation_type: CacheOperationType,
     pub succeeded: bool,
-    pub archive_size: Option<i64>,
+    pub archive_size: Option<ArchiveSize>,
     pub cache_key: Option<String>,
-    pub duration_ms: Option<i64>,
+    pub duration_ms: Option<Duration>,
 }

--- a/build-scan/server/graphql/src/lib.rs
+++ b/build-scan/server/graphql/src/lib.rs
@@ -340,7 +340,7 @@ impl CacheOperation {
     }
 
     fn archive_size(&self) -> Option<f64> {
-        self.op.archive_size.map(|s| s as f64)
+        self.op.archive_size.map(|s| s.0 as f64)
     }
 
     fn cache_key(&self) -> Option<&str> {
@@ -348,7 +348,7 @@ impl CacheOperation {
     }
 
     fn duration_ms(&self) -> Option<f64> {
-        self.op.duration_ms.map(|d| d as f64)
+        self.op.duration_ms.map(|d| d.0 as f64)
     }
 }
 
@@ -394,7 +394,7 @@ impl Test {
         self.test
             .duration_ms
             .map(|d| {
-                i32::try_from(d)
+                i32::try_from(d.0)
                     .map_err(|_| FieldError::from("duration_ms exceeds GraphQL Int range"))
             })
             .transpose()
@@ -420,22 +420,22 @@ pub struct TestSummary {
 #[graphql_object(context = Context)]
 impl TestSummary {
     fn passed(&self) -> i32 {
-        self.summary.passed as i32
+        self.summary.passed.0 as i32
     }
 
     fn failed(&self) -> i32 {
-        self.summary.failed as i32
+        self.summary.failed.0 as i32
     }
 
     fn skipped(&self) -> i32 {
-        self.summary.skipped as i32
+        self.summary.skipped.0 as i32
     }
 
     fn total_duration_ms(&self) -> FieldResult<Option<i32>> {
         self.summary
             .total_duration_ms
             .map(|d| {
-                i32::try_from(d)
+                i32::try_from(d.0)
                     .map_err(|_| FieldError::from("total_duration_ms exceeds GraphQL Int range"))
             })
             .transpose()

--- a/build-scan/server/service/src/lib.rs
+++ b/build-scan/server/service/src/lib.rs
@@ -163,13 +163,13 @@ impl BuildScanService {
                         task_builder.cacheable(c);
                     }
                     if let Some(ts) = task.started_at {
-                        task_builder.start_timestamp(ts);
+                        task_builder.start_timestamp(ts.as_i64());
                     }
                     if let Some(ts) = task.finished_at {
-                        task_builder.finish_timestamp(ts);
+                        task_builder.finish_timestamp(ts.as_i64());
                     }
                     if let Some(t) = task.origin_execution_time {
-                        task_builder.origin_execution_time(t);
+                        task_builder.origin_execution_time(t.as_i64());
                     }
                     if let Some(ck) = cache_key_str {
                         task_builder.cache_key(ck);
@@ -218,9 +218,13 @@ impl BuildScanService {
                             task_id: domain_task.id.clone(),
                             operation_type: map_cache_operation_type(&cache_op.operation_type),
                             succeeded,
-                            archive_size: cache_op.archive_size,
+                            archive_size: cache_op
+                                .archive_size
+                                .map(|s| domain::ArchiveSize(s.as_i64())),
                             cache_key: cache_op.cache_key.clone(),
-                            duration_ms: cache_op.duration_ms,
+                            duration_ms: cache_op
+                                .duration_ms
+                                .map(|d| domain::Duration(d.as_i64())),
                         };
                         db::insert_cache_operation(&mut *tx, &domain_op)
                             .await
@@ -251,7 +255,7 @@ impl BuildScanService {
                         test_builder.outcome(map_test_outcome(o));
                     }
                     if let Some(d) = test.duration_ms {
-                        test_builder.duration_ms(d);
+                        test_builder.duration_ms(d.as_i64());
                     }
 
                     let domain_test = test_builder


### PR DESCRIPTION
## Summary
- Replace raw `i64`/`i32`/`usize` with domain newtypes across the build-scan crates, preventing silent field-swap bugs (e.g. `started_at` vs `duration_ms`, archive bytes vs entry count).
- Wire layer (`build-scan/lib/src/models.rs`) adds 8 newtypes — `Duration`, `Timestamp`, `ArchiveSize`, `MemoryBytes`, `EntryCount`, `TaskCount`, `ProcessorCount`, `EventCount` — all `#[serde(transparent)]` so binary/JSON wire format is unchanged.
- Domain layer (`build-scan/server/domain/src/lib.rs`) adds `ArchiveSize` and `TestCount`; existing `Duration`/`Timestamp` are now applied consistently in `Test`, `TestSummary`, `CacheOperation`.
- `FrameHeader.timestamp` (byte-level wire struct) and the proxy crate were deliberately left untouched.

## Known follow-ups (not in this PR)
- No dedicated serde round-trip unit tests for the new wrappers (exercised transitively by existing parse tests).
- GraphQL resolvers reach into domain newtypes via `.0`; adding `as_i64()` accessors on domain types would reduce coupling but was out of scope.