### PR TITLE
chore(renovate): keep lock file maintenance running daily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 5am on monday"]
+    "schedule": ["* 0-4 * * *"]
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["* 0-4 * * *"]
+    "schedule": ["0 4 * * *"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- change Renovate lock file maintenance from weekly Monday mornings to a daily early-morning cadence
- keep the change scoped to `lockFileMaintenance.schedule` only

## Verification
- `python -m json.tool renovate.json`
- `bazel run gazelle`

## Known verification blockers
- `bazel run //tools/format` fails because the generated script expects `/bin/bash`
- `aspect lint //...` fails with an existing Bazel package-loading issue under `node_modules/flatted/golang/pkg/flatted`
- `aspect test //...` fails with the same existing Bazel package-loading issue
- `aspect build //...` fails with the same existing Bazel package-loading issue