### PR TITLE
chore(renovate): fix lock file maintenance schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["0 4 * * *"]
+    "schedule": ["* 4 * * *"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- fix the Renovate `lockFileMaintenance.schedule` value so it uses Renovate-valid cron syntax
- keep lock file maintenance running daily at 04:00 with the minimal config change
- leave all other Renovate behavior unchanged