### PR TITLE
draft: extract configuration dependency feature from mixed task graph worktree

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-dependencies-tab.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-dependencies-tab.component.spec.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { TestBed, type ComponentFixture } from "@angular/core/testing";
+import {
+  ApolloTestingController,
+  ApolloTestingModule,
+} from "apollo-angular/testing";
+import { ScanDependenciesTabComponent } from "./scan-dependencies-tab.component";
+
+function buildConfigurationSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "6648731359144961106",
+    displayName: ":app:build",
+    details: [":list:build", ":utilities:build"],
+    ...overrides,
+  };
+}
+
+function buildConfigurationGraph(overrides: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      { id: "configuration:6648731359144961106", label: ":app:build" },
+      {
+        id: "dependency:6648731359144961106:0",
+        label: "junit-jupiter-api-5.12.1.jar",
+      },
+    ],
+    edges: [
+      {
+        sourceId: "configuration:6648731359144961106",
+        targetId: "dependency:6648731359144961106:0",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("ScanDependenciesTabComponent", () => {
+  let fixture: ComponentFixture<ScanDependenciesTabComponent>;
+  let controller: ApolloTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApolloTestingModule, ScanDependenciesTabComponent],
+    });
+    controller = TestBed.inject(ApolloTestingController);
+    fixture = TestBed.createComponent(ScanDependenciesTabComponent);
+    fixture.componentRef.setInput("scanId", "QnVpbGRTY2FuOjEyMw==");
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    controller.match("GetScanConfigurationDependencies");
+    controller.match("GetScanConfigurationDependencyGraph");
+    controller.verify();
+  });
+
+  it("loads configuration summaries when the tab mounts", () => {
+    const pending = controller.expectOne("GetScanConfigurationDependencies");
+    expect(pending.operation.variables).toEqual({
+      id: "QnVpbGRTY2FuOjEyMw==",
+    });
+    expect(fixture.nativeElement.textContent).toContain(
+      "Loading configurations…",
+    );
+
+    pending.flushData({
+      buildScan: {
+        id: "QnVpbGRTY2FuOjEyMw==",
+        configurationDependencies: [buildConfigurationSummary()],
+      },
+    });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain("Configurations");
+    expect(fixture.nativeElement.textContent).toContain(":app:build");
+    expect(
+      controller.match("GetScanConfigurationDependencyGraph"),
+    ).toHaveLength(0);
+  });
+
+  it("fetches the selected configuration graph only after a click", async () => {
+    controller.expectOne("GetScanConfigurationDependencies").flushData({
+      buildScan: {
+        id: "QnVpbGRTY2FuOjEyMw==",
+        configurationDependencies: [buildConfigurationSummary()],
+      },
+    });
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector(
+      "aside button",
+    ) as HTMLButtonElement | null;
+    expect(button).toBeTruthy();
+
+    if (!button) {
+      throw new Error("Configuration button not found");
+    }
+    button.click();
+    fixture.detectChanges();
+
+    const pendingGraph = controller.expectOne(
+      "GetScanConfigurationDependencyGraph",
+    );
+    expect(pendingGraph.operation.variables).toEqual({
+      id: "QnVpbGRTY2FuOjEyMw==",
+      configurationId: "6648731359144961106",
+    });
+    expect(fixture.nativeElement.textContent).toContain(
+      "Loading dependency graph for :app:build…",
+    );
+
+    pendingGraph.flushData({
+      buildScan: {
+        id: "QnVpbGRTY2FuOjEyMw==",
+        configurationDependencyGraph: buildConfigurationGraph(),
+      },
+    });
+    for (const refetch of controller.match(
+      "GetScanConfigurationDependencies",
+    )) {
+      refetch.flushData({
+        buildScan: {
+          id: "QnVpbGRTY2FuOjEyMw==",
+          configurationDependencies: [buildConfigurationSummary()],
+        },
+      });
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector(
+        '[data-testid="configuration-dependency-graph"]',
+      ),
+    ).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain(
+      "junit-jupiter-api-5.12.1.jar",
+    );
+  });
+});

--- a/angular/projects/build-scan-web/src/app/scans/scan-dependencies-tab.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-dependencies-tab.component.ts
@@ -1,0 +1,502 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  input,
+  signal,
+} from "@angular/core";
+import { takeUntilDestroyed, toObservable } from "@angular/core/rxjs-interop";
+import type { OnInit } from "@angular/core";
+import { Apollo, gql } from "apollo-angular";
+import { filter, map, switchMap, tap } from "rxjs";
+
+interface ConfigurationDependencySummary {
+  id: string;
+  displayName: string;
+  details: string[];
+}
+
+interface ConfigurationDependencyNode {
+  id: string;
+  label: string;
+}
+
+interface ConfigurationDependencyEdge {
+  sourceId: string;
+  targetId: string;
+}
+
+interface ConfigurationDependencyGraph {
+  nodes: ConfigurationDependencyNode[];
+  edges: ConfigurationDependencyEdge[];
+}
+
+interface ConfigurationDependencyListData {
+  buildScan: {
+    id: string;
+    configurationDependencies: ConfigurationDependencySummary[];
+  } | null;
+}
+
+interface ConfigurationDependencyListVariables {
+  id: string;
+}
+
+interface ConfigurationDependencyGraphData {
+  buildScan: {
+    id: string;
+    configurationDependencyGraph: ConfigurationDependencyGraph | null;
+  } | null;
+}
+
+interface ConfigurationDependencyGraphVariables {
+  id: string;
+  configurationId: string;
+}
+
+interface RenderedNode extends ConfigurationDependencyNode {
+  x: number;
+  y: number;
+}
+
+function isConfigurationDependencySummary(
+  configuration: Partial<ConfigurationDependencySummary> | null | undefined,
+): configuration is ConfigurationDependencySummary {
+  return (
+    !!configuration &&
+    typeof configuration.id === "string" &&
+    typeof configuration.displayName === "string" &&
+    Array.isArray(configuration.details)
+  );
+}
+
+const GET_SCAN_CONFIGURATION_DEPENDENCIES = gql`
+  query GetScanConfigurationDependencies($id: ID!) {
+    buildScan(id: $id) {
+      id
+      configurationDependencies {
+        id
+        displayName
+        details
+      }
+    }
+  }
+`;
+
+const GET_SCAN_CONFIGURATION_DEPENDENCY_GRAPH = gql`
+  query GetScanConfigurationDependencyGraph(
+    $id: ID!
+    $configurationId: String!
+  ) {
+    buildScan(id: $id) {
+      id
+      configurationDependencyGraph(configurationId: $configurationId) {
+        nodes {
+          id
+          label
+        }
+        edges {
+          sourceId
+          targetId
+        }
+      }
+    }
+  }
+`;
+
+@Component({
+  selector: "app-scan-dependencies-tab",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="space-y-6">
+      <h2 class="text-2xl font-bold">Dependencies</h2>
+
+      @if (loadingConfigurations()) {
+        <div
+          class="rounded-md border border-base-300 bg-base-200 p-4 text-sm opacity-70"
+        >
+          Loading configurations…
+        </div>
+      } @else if (configurations().length === 0) {
+        <div
+          class="rounded-md border border-base-300 bg-base-200 p-4 text-sm opacity-70"
+        >
+          No configuration dependencies recorded for this scan.
+        </div>
+      } @else {
+        <div class="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+          <aside
+            class="rounded-box border border-base-300 bg-base-200 p-3 lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto"
+          >
+            <div class="mb-3">
+              <h3 class="font-semibold">Configurations</h3>
+              <p class="text-xs opacity-60">
+                Select a configuration to load its dependency graph.
+              </p>
+            </div>
+
+            <div class="space-y-2">
+              @for (configuration of configurations(); track configuration.id) {
+                <button
+                  type="button"
+                  class="w-full rounded-md border px-3 py-2 text-left transition-colors"
+                  [class.border-primary]="
+                    selectedConfigurationId() === configuration.id
+                  "
+                  [class.bg-primary/10]="
+                    selectedConfigurationId() === configuration.id
+                  "
+                  [class.border-base-300]="
+                    selectedConfigurationId() !== configuration.id
+                  "
+                  [class.hover:bg-base-300]="
+                    selectedConfigurationId() !== configuration.id
+                  "
+                  (click)="selectConfiguration(configuration)"
+                >
+                  <div class="font-medium break-words">
+                    {{ configuration.displayName }}
+                  </div>
+                  @if (configuration.details.length > 0) {
+                    <div class="mt-1 text-xs opacity-60 break-words">
+                      {{ configuration.details.join(" · ") }}
+                    </div>
+                  }
+                </button>
+              }
+            </div>
+          </aside>
+
+          <section class="space-y-4">
+            @if (!selectedConfiguration()) {
+              <div
+                class="rounded-md border border-base-300 bg-base-200 p-4 text-sm opacity-70"
+              >
+                Select a configuration from the list to fetch and render its
+                dependencies.
+              </div>
+            } @else if (loadingGraph()) {
+              <div
+                class="rounded-md border border-base-300 bg-base-200 p-4 text-sm opacity-70"
+              >
+                Loading dependency graph for
+                {{ selectedConfiguration()!.displayName }}…
+              </div>
+            } @else if (selectedGraph(); as graph) {
+              <div class="card bg-base-200">
+                <div class="card-body p-4">
+                  <div class="mb-3 flex items-start justify-between gap-4">
+                    <div>
+                      <h3 class="font-semibold">
+                        {{ selectedConfiguration()!.displayName }}
+                      </h3>
+                      @if (selectedConfiguration()!.details.length > 0) {
+                        <p class="text-xs opacity-60 break-words">
+                          {{ selectedConfiguration()!.details.join(" · ") }}
+                        </p>
+                      }
+                    </div>
+                    <div class="text-xs opacity-60">
+                      {{ graph.nodes.length }} nodes · {{ graph.edges.length }}
+                      edges
+                    </div>
+                  </div>
+
+                  @if (graph.nodes.length > 0) {
+                    <div
+                      class="overflow-x-auto rounded-box border border-base-300 bg-base-100/40 p-3"
+                    >
+                      <svg
+                        data-testid="configuration-dependency-graph"
+                        [attr.viewBox]="
+                          '0 0 ' +
+                          graphLayout().width +
+                          ' ' +
+                          graphLayout().height
+                        "
+                        [attr.width]="graphLayout().width"
+                        [attr.height]="graphLayout().height"
+                        class="h-auto min-w-full text-base-content"
+                      >
+                        <defs>
+                          <marker
+                            id="configuration-dependency-arrow"
+                            viewBox="0 0 10 10"
+                            refX="9"
+                            refY="5"
+                            markerWidth="6"
+                            markerHeight="6"
+                            orient="auto-start-reverse"
+                          >
+                            <path
+                              d="M 0 0 L 10 5 L 0 10 z"
+                              fill="currentColor"
+                            ></path>
+                          </marker>
+                        </defs>
+
+                        @for (
+                          edge of graphLayout().edges;
+                          track edge.sourceId + ":" + edge.targetId
+                        ) {
+                          <path
+                            [attr.d]="edge.path"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            opacity="0.35"
+                            marker-end="url(#configuration-dependency-arrow)"
+                          ></path>
+                        }
+
+                        @for (node of graphLayout().nodes; track node.id) {
+                          <g
+                            [attr.transform]="
+                              'translate(' + node.x + ' ' + node.y + ')'
+                            "
+                          >
+                            <title>{{ node.label }}</title>
+                            <rect
+                              x="0"
+                              y="0"
+                              width="260"
+                              height="52"
+                              rx="12"
+                              fill="oklch(55% 0.04 260 / 0.12)"
+                              stroke="oklch(55% 0.04 260)"
+                              stroke-width="2"
+                            ></rect>
+                            <text
+                              x="16"
+                              y="29"
+                              fill="currentColor"
+                              font-size="14"
+                              font-weight="600"
+                            >
+                              {{ truncateLabel(node.label) }}
+                            </text>
+                          </g>
+                        }
+                      </svg>
+                    </div>
+                  } @else {
+                    <p class="text-sm opacity-60">
+                      No configuration dependency graph available.
+                    </p>
+                  }
+                </div>
+              </div>
+            } @else {
+              <div
+                class="rounded-md border border-base-300 bg-base-200 p-4 text-sm opacity-70"
+              >
+                No configuration dependency graph available.
+              </div>
+            }
+          </section>
+        </div>
+      }
+    </div>
+  `,
+})
+export class ScanDependenciesTabComponent implements OnInit {
+  scanId = input.required<string>();
+
+  private apollo = inject(Apollo);
+  private destroyRef = inject(DestroyRef);
+  private scanId$ = toObservable(this.scanId);
+  private graphCache = new Map<string, ConfigurationDependencyGraph | null>();
+
+  configurations = signal<ConfigurationDependencySummary[]>([]);
+  selectedConfigurationId = signal<string | null>(null);
+  selectedGraph = signal<ConfigurationDependencyGraph | null>(null);
+  loadingConfigurations = signal(true);
+  loadingGraph = signal(false);
+
+  selectedConfiguration = computed(() => {
+    const selectedId = this.selectedConfigurationId();
+    if (!selectedId) return null;
+    return (
+      this.configurations().find(
+        (configuration) => configuration.id === selectedId,
+      ) ?? null
+    );
+  });
+
+  graphLayout = computed(() => {
+    const graph = this.selectedGraph();
+    if (!graph) {
+      return {
+        nodes: [] as RenderedNode[],
+        edges: [] as Array<{
+          sourceId: string;
+          targetId: string;
+          path: string;
+        }>,
+        width: 0,
+        height: 0,
+      };
+    }
+
+    const incoming = new Map<string, number>();
+    for (const node of graph.nodes) {
+      incoming.set(node.id, 0);
+    }
+    for (const edge of graph.edges) {
+      incoming.set(edge.targetId, (incoming.get(edge.targetId) ?? 0) + 1);
+    }
+
+    const roots = graph.nodes.filter(
+      (node) => (incoming.get(node.id) ?? 0) === 0,
+    );
+    const rootIds = new Set(roots.map((node) => node.id));
+    const children = graph.nodes.filter((node) => !rootIds.has(node.id));
+    const leftColumn = roots.length > 0 ? roots : graph.nodes.slice(0, 1);
+    const rightColumn = children.length > 0 ? children : graph.nodes.slice(1);
+    const positionedNodes = new Map<string, RenderedNode>();
+
+    for (const [index, node] of leftColumn.entries()) {
+      positionedNodes.set(node.id, {
+        id: node.id,
+        label: node.label,
+        x: 24,
+        y: 24 + index * 80,
+      });
+    }
+    for (const [index, node] of rightColumn.entries()) {
+      positionedNodes.set(node.id, {
+        id: node.id,
+        label: node.label,
+        x: 360,
+        y: 24 + index * 80,
+      });
+    }
+
+    for (const node of graph.nodes) {
+      if (!positionedNodes.has(node.id)) {
+        positionedNodes.set(node.id, {
+          id: node.id,
+          label: node.label,
+          x: 360,
+          y: 24 + positionedNodes.size * 80,
+        });
+      }
+    }
+
+    const renderedNodes = Array.from(positionedNodes.values());
+    const renderedEdges = graph.edges
+      .map((edge) => {
+        const source = positionedNodes.get(edge.sourceId);
+        const target = positionedNodes.get(edge.targetId);
+        if (!source || !target) return null;
+        const startX = source.x + 260;
+        const startY = source.y + 26;
+        const endX = target.x;
+        const endY = target.y + 26;
+        const controlX = startX + (endX - startX) / 2;
+        return {
+          sourceId: edge.sourceId,
+          targetId: edge.targetId,
+          path: `M ${startX} ${startY} C ${controlX} ${startY}, ${controlX} ${endY}, ${endX} ${endY}`,
+        };
+      })
+      .filter(
+        (edge): edge is { sourceId: string; targetId: string; path: string } =>
+          edge !== null,
+      );
+
+    return {
+      nodes: renderedNodes,
+      edges: renderedEdges,
+      width: 660,
+      height: Math.max(120, renderedNodes.length * 80),
+    };
+  });
+
+  ngOnInit() {
+    this.scanId$
+      .pipe(
+        switchMap((id) => {
+          this.graphCache.clear();
+          this.configurations.set([]);
+          this.selectedConfigurationId.set(null);
+          this.selectedGraph.set(null);
+          this.loadingConfigurations.set(true);
+          this.loadingGraph.set(false);
+
+          return this.apollo
+            .watchQuery<
+              ConfigurationDependencyListData,
+              ConfigurationDependencyListVariables
+            >({
+              query: GET_SCAN_CONFIGURATION_DEPENDENCIES,
+              variables: { id },
+              errorPolicy: "all",
+            })
+            .valueChanges.pipe(
+              filter((result) => !!result.data),
+              map(
+                (result) =>
+                  result.data?.buildScan?.configurationDependencies ?? [],
+              ),
+              map((configurations) =>
+                configurations.filter(isConfigurationDependencySummary),
+              ),
+              tap((configurations) => {
+                this.configurations.set(configurations);
+                this.loadingConfigurations.set(false);
+              }),
+            );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  selectConfiguration(configuration: ConfigurationDependencySummary) {
+    this.selectedConfigurationId.set(configuration.id);
+
+    if (this.graphCache.has(configuration.id)) {
+      this.selectedGraph.set(this.graphCache.get(configuration.id) ?? null);
+      this.loadingGraph.set(false);
+      return;
+    }
+
+    this.loadingGraph.set(true);
+    this.selectedGraph.set(null);
+
+    this.apollo
+      .query<
+        ConfigurationDependencyGraphData,
+        ConfigurationDependencyGraphVariables
+      >({
+        query: GET_SCAN_CONFIGURATION_DEPENDENCY_GRAPH,
+        variables: {
+          id: this.scanId(),
+          configurationId: configuration.id,
+        },
+        errorPolicy: "all",
+        fetchPolicy: "no-cache",
+      })
+      .pipe(
+        map(
+          (result) =>
+            result.data?.buildScan?.configurationDependencyGraph ?? null,
+        ),
+        tap((graph) => {
+          this.graphCache.set(configuration.id, graph);
+          this.selectedGraph.set(graph);
+          this.loadingGraph.set(false);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  truncateLabel(label: string) {
+    if (label.length <= 32) return label;
+    return `${label.slice(0, 29)}…`;
+  }
+}

--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { TestBed, type ComponentFixture } from "@angular/core/testing";
 import {
   ApolloTestingModule,
   ApolloTestingController,
@@ -92,6 +92,22 @@ function buildTestScan(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function buildConfigurationDependenciesScan(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: "QnVpbGRTY2FuOjEyMw==",
+    configurationDependencies: [
+      {
+        id: "6648731359144961106",
+        displayName: ":app:build",
+        details: [":list:build", ":utilities:build"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
 describe("ScanDetailComponent", () => {
   let fixture: ComponentFixture<ScanDetailComponent>;
   let controller: ApolloTestingController;
@@ -132,7 +148,10 @@ describe("ScanDetailComponent", () => {
       candidate.textContent?.includes(label),
     );
     expect(button, `button ${label}`).toBeTruthy();
-    button!.click();
+    if (!button) {
+      throw new Error(`button ${label} not found`);
+    }
+    button.click();
     fixture.detectChanges();
   }
 
@@ -159,8 +178,12 @@ describe("ScanDetailComponent", () => {
     expect(
       fixture.nativeElement.querySelector("app-scan-tests-tab"),
     ).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector("app-scan-dependencies-tab"),
+    ).toBeNull();
     expect(fixture.componentInstance.selectedTab()).toBe("overview");
     expect(fixture.componentInstance.isTabMounted("tasks")).toBe(false);
+    expect(fixture.componentInstance.isTabMounted("dependencies")).toBe(false);
     expect(fixture.componentInstance.isTabMounted("tests")).toBe(false);
   });
 
@@ -197,6 +220,45 @@ describe("ScanDetailComponent", () => {
       controller.match((op) => op.operationName === "GetScanTasks"),
     ).toHaveLength(0);
     expect(fixture.componentInstance.selectedTab()).toBe("tasks");
+  });
+
+  it("loads the Dependencies tab on demand", () => {
+    flushOverview();
+
+    clickTab("Dependencies");
+
+    const pendingDependencies = controller.expectOne(
+      "GetScanConfigurationDependencies",
+    );
+    expect(pendingDependencies.operation.variables).toEqual({
+      id: "QnVpbGRTY2FuOjEyMw==",
+    });
+    expect(fixture.nativeElement.textContent).toContain(
+      "Loading configurations…",
+    );
+
+    pendingDependencies.flushData({
+      buildScan: buildConfigurationDependenciesScan(),
+    });
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector("app-scan-dependencies-tab"),
+    ).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain("Configurations");
+    expect(fixture.componentInstance.selectedTab()).toBe("dependencies");
+    expect(fixture.componentInstance.isTabMounted("dependencies")).toBe(true);
+
+    clickTab("Overview");
+    expect(fixture.componentInstance.selectedTab()).toBe("overview");
+
+    clickTab("Dependencies");
+    expect(
+      controller.match(
+        (op) => op.operationName === "GetScanConfigurationDependencies",
+      ),
+    ).toHaveLength(0);
+    expect(fixture.componentInstance.selectedTab()).toBe("dependencies");
   });
 
   it("loads the Tests tab on demand", () => {
@@ -256,6 +318,7 @@ describe("ScanDetailComponent", () => {
 
     expect(fixture.componentInstance.selectedTab()).toBe("overview");
     expect(fixture.componentInstance.isTabMounted("tasks")).toBe(false);
+    expect(fixture.componentInstance.isTabMounted("dependencies")).toBe(false);
     expect(fixture.componentInstance.isTabMounted("tests")).toBe(false);
 
     clickTab("Tasks");

--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -11,11 +11,39 @@ import { Apollo, gql } from "apollo-angular";
 import { filter, map, switchMap } from "rxjs";
 import { toObservable } from "@angular/core/rxjs-interop";
 import { BuildMetadataComponent } from "./build-metadata/build-metadata.component";
-import { ScanSidebarComponent } from "./scan-sidebar/scan-sidebar.component";
+import { ScanDependenciesTabComponent } from "./scan-dependencies-tab.component";
+import {
+  ScanSidebarComponent,
+  type ScanTab,
+} from "./scan-sidebar/scan-sidebar.component";
 import { ScanTasksTabComponent } from "./scan-tasks-tab.component";
 import { ScanTestsTabComponent } from "./scan-tests-tab.component";
 
-type ScanTab = "overview" | "tasks" | "tests";
+interface BuildScanOverview {
+  id: string;
+  scanId: string;
+  buildToolType: string;
+  buildToolVersion: string;
+  pluginVersion: string;
+  outcome: string | null;
+  createdAt: string;
+  hostname: string | null;
+  osName: string | null;
+  osVersion: string | null;
+  jvmVendor: string | null;
+  jvmVersion: string | null;
+  requestedTasks: string[];
+  taskCount: number;
+  testCount: number;
+}
+
+interface GetBuildScanOverviewData {
+  buildScan: BuildScanOverview | null;
+}
+
+interface GetBuildScanOverviewVariables {
+  id: string;
+}
 
 const GET_BUILD_SCAN_OVERVIEW = gql`
   query GetBuildScanOverview($id: ID!) {
@@ -44,6 +72,7 @@ const GET_BUILD_SCAN_OVERVIEW = gql`
   imports: [
     AsyncPipe,
     BuildMetadataComponent,
+    ScanDependenciesTabComponent,
     ScanSidebarComponent,
     ScanTasksTabComponent,
     ScanTestsTabComponent,
@@ -74,6 +103,12 @@ const GET_BUILD_SCAN_OVERVIEW = gql`
             </section>
           }
 
+          @if (isTabMounted("dependencies")) {
+            <section [hidden]="selectedTab() !== 'dependencies'">
+              <app-scan-dependencies-tab [scanId]="scan.id" />
+            </section>
+          }
+
           @if (isTabMounted("tests")) {
             <section [hidden]="selectedTab() !== 'tests'">
               <app-scan-tests-tab
@@ -99,7 +134,7 @@ export class ScanDetailComponent {
   scan$ = toObservable(this.id).pipe(
     switchMap((id) =>
       this.apollo
-        .watchQuery<any>({
+        .watchQuery<GetBuildScanOverviewData, GetBuildScanOverviewVariables>({
           query: GET_BUILD_SCAN_OVERVIEW,
           variables: { id },
           errorPolicy: "all",
@@ -107,6 +142,7 @@ export class ScanDetailComponent {
         .valueChanges.pipe(
           filter((result) => !!result.data),
           map((result) => result.data.buildScan),
+          filter((scan): scan is BuildScanOverview => scan !== null),
         ),
     ),
   );

--- a/angular/projects/build-scan-web/src/app/scans/scan-sidebar/scan-sidebar.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-sidebar/scan-sidebar.component.spec.ts
@@ -39,14 +39,14 @@ describe("ScanSidebarComponent", () => {
     return fixture;
   }
 
-  it("renders the Overview, Tasks, and Tests tab controls", () => {
+  it("renders the Overview, Tasks, Dependencies, and Tests tab controls", () => {
     const fixture = render();
     const buttons = Array.from(
       fixture.nativeElement.querySelectorAll("nav button"),
     ) as HTMLButtonElement[];
     const labels = buttons.map((button) => button.textContent?.trim());
 
-    expect(labels).toEqual(["Overview", "Tasks", "Tests"]);
+    expect(labels).toEqual(["Overview", "Tasks", "Dependencies", "Tests"]);
     expect(fixture.nativeElement.textContent).not.toContain("Cache Avoidance");
   });
 
@@ -64,7 +64,10 @@ describe("ScanSidebarComponent", () => {
     ) as HTMLElement | undefined;
     expect(tasksButton).toBeTruthy();
 
-    tasksButton!.click();
+    if (!tasksButton) {
+      throw new Error("Tasks button not found");
+    }
+    tasksButton.click();
     expect(clicked).toBe("tasks");
   });
 

--- a/angular/projects/build-scan-web/src/app/scans/scan-sidebar/scan-sidebar.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-sidebar/scan-sidebar.component.ts
@@ -7,7 +7,24 @@ import {
 import { DatePipe } from "@angular/common";
 import { RouterLink } from "@angular/router";
 
-type ScanTab = "overview" | "tasks" | "tests";
+export type ScanTab = "overview" | "tasks" | "dependencies" | "tests";
+
+interface SidebarScan {
+  scanId: string;
+  outcome: string | null;
+  createdAt: string;
+  requestedTasks: string[];
+  taskCount: number;
+  testCount: number;
+  buildToolType: string;
+  buildToolVersion: string;
+  pluginVersion: string;
+  hostname: string | null;
+  osName: string | null;
+  osVersion: string | null;
+  jvmVendor: string | null;
+  jvmVersion: string | null;
+}
 
 interface TabNav {
   id: ScanTab;
@@ -177,13 +194,14 @@ interface TabNav {
   `,
 })
 export class ScanSidebarComponent {
-  scan = input.required<any>();
+  scan = input.required<SidebarScan>();
   activeTab = input<ScanTab>("overview");
   tabClicked = output<ScanTab>();
 
   tabs: TabNav[] = [
     { id: "overview", label: "Overview" },
     { id: "tasks", label: "Tasks" },
+    { id: "dependencies", label: "Dependencies" },
     { id: "tests", label: "Tests" },
   ];
 

--- a/build-scan/lib/src/assembly.rs
+++ b/build-scan/lib/src/assembly.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use events::DecodedEvent;
 use framing::FramedEvent;
@@ -43,10 +43,17 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
     let mut os_event: Option<events::OsEvent> = None;
     let mut jvm_event: Option<events::JvmEvent> = None;
     let mut requested_tasks: Vec<String> = Vec::new();
+    let mut configuration_resolution_started: BTreeMap<i64, Vec<String>> = BTreeMap::new();
+    let mut configuration_resolution_finished: BTreeMap<i64, Vec<String>> = BTreeMap::new();
+    let mut build_wide_configuration_dependencies: Option<
+        events::BuildWideConfigurationDependenciesEvent,
+    > = None;
 
     // Cache operation tracking: operation_id → (work_id, op_type, cache_key, started_archive_size, started_timestamp)
-    let mut cache_op_started: HashMap<i64, (i64, CacheOperationType, Option<String>, Option<i64>, i64)> =
-        HashMap::new();
+    let mut cache_op_started: HashMap<
+        i64,
+        (i64, CacheOperationType, Option<String>, Option<i64>, i64),
+    > = HashMap::new();
     let mut cache_op_finished: HashMap<i64, CacheOpFinished> = HashMap::new();
 
     for (frame, decoded) in &events {
@@ -179,14 +186,17 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                         .executor_name
                         .clone()
                         .or_else(|| executor_names.get(&e.executor_id).cloned());
-                    all_test_cases.push((Some(models::TestCase {
-                        class_name: e.class_name.clone(),
-                        method_name: e.method_name.clone(),
-                        executor_name,
-                        outcome: None,
-                        duration_ms: None,
-                        failure_id: None,
-                    }), frame.timestamp));
+                    all_test_cases.push((
+                        Some(models::TestCase {
+                            class_name: e.class_name.clone(),
+                            method_name: e.method_name.clone(),
+                            executor_name,
+                            outcome: None,
+                            duration_ms: None,
+                            failure_id: None,
+                        }),
+                        frame.timestamp,
+                    ));
                 } else {
                     // Non-method event (class-level or executor-init): placeholder to
                     // keep positional alignment with TestResult events.
@@ -367,6 +377,15 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                     },
                 );
             }
+            DecodedEvent::ConfigurationResolutionStarted(e) => {
+                configuration_resolution_started.insert(e.id, e.labels.clone());
+            }
+            DecodedEvent::ConfigurationResolutionFinished(e) => {
+                configuration_resolution_finished.insert(e.id, e.labels.clone());
+            }
+            DecodedEvent::BuildWideConfigurationDependencies(e) => {
+                build_wide_configuration_dependencies = Some(e.clone());
+            }
             DecodedEvent::Raw(r) => {
                 *raw_counts.entry(r.wire_id).or_insert(0) += 1;
             }
@@ -479,8 +498,7 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
                 duration_ms: duration_ms.map(models::Duration::new),
                 inputs,
                 up_to_date_messages: fin.and_then(|f| f.up_to_date_messages.clone()),
-                origin_build_invocation_id: fin
-                    .and_then(|f| f.origin_build_invocation_id.clone()),
+                origin_build_invocation_id: fin.and_then(|f| f.origin_build_invocation_id.clone()),
                 origin_execution_time: fin
                     .and_then(|f| f.origin_execution_time)
                     .map(models::Duration::new),
@@ -560,10 +578,38 @@ pub fn assemble(events: Vec<(FramedEvent, DecodedEvent)>) -> BuildScanPayload {
         })
         .collect();
 
+    let mut configuration_ids: Vec<i64> = configuration_resolution_started
+        .keys()
+        .chain(configuration_resolution_finished.keys())
+        .copied()
+        .collect();
+    configuration_ids.sort_unstable();
+    configuration_ids.dedup();
+
+    let configuration_resolutions = configuration_ids
+        .into_iter()
+        .map(|id| models::ConfigurationResolutionData {
+            id,
+            started_labels: configuration_resolution_started
+                .remove(&id)
+                .unwrap_or_default(),
+            finished_labels: configuration_resolution_finished
+                .remove(&id)
+                .unwrap_or_default(),
+        })
+        .collect();
+
     BuildScanPayload {
         tasks,
         planned_nodes: planned_nodes_data,
         transform_execution_requests: transform_requests_data,
+        configuration_resolutions,
+        build_wide_configuration_dependencies: build_wide_configuration_dependencies.map(|event| {
+            models::BuildWideConfigurationDependenciesData {
+                root_node_id: event.root_node_id,
+                artifact_labels: event.artifact_labels,
+            }
+        }),
         raw_events,
         task_registration_summary: task_registration_summary.map(|e| {
             models::TaskRegistrationSummaryData {
@@ -854,8 +900,14 @@ mod tests {
             "testFail: 2001 - 2000 = 1ms"
         );
         // failure_id is propagated from TestResult
-        assert!(payload.tests[0].failure_id.is_none(), "passing test should have no failure_id");
-        assert_eq!(payload.tests[1].failure_id, Some(models::FailureId::new(42)));
+        assert!(
+            payload.tests[0].failure_id.is_none(),
+            "passing test should have no failure_id"
+        );
+        assert_eq!(
+            payload.tests[1].failure_id,
+            Some(models::FailureId::new(42))
+        );
     }
 
     #[test]
@@ -884,7 +936,10 @@ mod tests {
         ];
         let payload = assemble(events);
         assert_eq!(payload.tests.len(), 1);
-        assert_eq!(payload.tests[0].duration_ms, None, "negative duration should produce None");
+        assert_eq!(
+            payload.tests[0].duration_ms, None,
+            "negative duration should produce None"
+        );
     }
 
     #[test]
@@ -1023,7 +1078,9 @@ mod tests {
 
     #[test]
     fn test_assemble_cache_operation_duration_none_when_finished_missing() {
-        use events::{BuildCacheLocalLoadStartedEvent, TaskFinishedEvent, TaskIdentityEvent, TaskStartedEvent};
+        use events::{
+            BuildCacheLocalLoadStartedEvent, TaskFinishedEvent, TaskIdentityEvent, TaskStartedEvent,
+        };
         use models::CacheOperationType;
 
         let task_id = TaskId::new(99);

--- a/build-scan/lib/src/events/BUILD.bazel
+++ b/build-scan/lib/src/events/BUILD.bazel
@@ -15,6 +15,7 @@ rust_library(
         "build_modes.rs",
         "build_requested_tasks.rs",
         "build_started.rs",
+        "configuration_dependencies.rs",
         "daemon_state.rs",
         "encoding.rs",
         "file_ref_roots.rs",
@@ -65,4 +66,5 @@ rust_library(
 rust_test(
     name = "events_test",
     crate = ":events",
+    deps = ["@crates//:hex"],
 )

--- a/build-scan/lib/src/events/configuration_dependencies.rs
+++ b/build-scan/lib/src/events/configuration_dependencies.rs
@@ -1,0 +1,223 @@
+use error::ParseError;
+
+use super::{
+    BodyDecoder, BuildWideConfigurationDependenciesEvent, ConfigurationResolutionFinishedEvent,
+    ConfigurationResolutionStartedEvent, DecodedEvent,
+};
+
+const FIXED_ID_PREFIX_LEN: usize = 9;
+const MAX_SCANNED_STRING_LEN: usize = 256;
+
+fn is_human_readable_char(ch: char) -> bool {
+    matches!(ch, ' '..='~')
+}
+
+fn is_human_readable_string(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+
+    if value.len() < 4 && value != ":" {
+        return false;
+    }
+
+    if !value.chars().all(is_human_readable_char) {
+        return false;
+    }
+
+    value
+        .chars()
+        .any(|ch| ch.is_ascii_alphanumeric() || matches!(ch, ':' | '/' | '.' | '-' | '_' | ' '))
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !value.is_empty() && !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn try_read_inline_string(data: &[u8], start: usize) -> Option<(String, usize)> {
+    let mut pos = start;
+    let raw_len = kryo::read_zigzag_i64(data, &mut pos).ok()?;
+    if raw_len <= 0 {
+        return None;
+    }
+
+    let char_count = usize::try_from(raw_len).ok()?;
+    if char_count > MAX_SCANNED_STRING_LEN {
+        return None;
+    }
+
+    let mut value = String::with_capacity(char_count);
+    for _ in 0..char_count {
+        let code_point = varint::read_unsigned_varint(data, &mut pos).ok()? as u32;
+        let ch = char::from_u32(code_point)?;
+        if !is_human_readable_char(ch) {
+            return None;
+        }
+        value.push(ch);
+    }
+
+    if !is_human_readable_string(&value) {
+        return None;
+    }
+
+    Some((value, pos))
+}
+
+fn extract_human_readable_strings(data: &[u8]) -> Vec<String> {
+    let mut strings = Vec::new();
+    let mut pos = 0;
+
+    while pos < data.len() {
+        if let Some((value, next_pos)) = try_read_inline_string(data, pos) {
+            push_unique(&mut strings, value);
+            pos = next_pos;
+        } else {
+            pos += 1;
+        }
+    }
+
+    strings
+}
+
+fn read_event_id(body: &[u8]) -> i64 {
+    if body.len() < FIXED_ID_PREFIX_LEN {
+        return 0;
+    }
+
+    i64::from_le_bytes([
+        body[1], body[2], body[3], body[4], body[5], body[6], body[7], body[8],
+    ])
+}
+
+fn extract_resolution_labels(body: &[u8]) -> Vec<String> {
+    if body.len() <= FIXED_ID_PREFIX_LEN {
+        return Vec::new();
+    }
+
+    extract_human_readable_strings(&body[FIXED_ID_PREFIX_LEN..])
+}
+
+fn looks_like_dependency_artifact_label(value: &str) -> bool {
+    value.ends_with(".jar") || value.ends_with(".klib") || value.ends_with(".pom")
+}
+
+pub struct ConfigurationResolutionStartedDecoder;
+
+impl BodyDecoder for ConfigurationResolutionStartedDecoder {
+    fn decode(&self, body: &[u8]) -> Result<DecodedEvent, ParseError> {
+        Ok(DecodedEvent::ConfigurationResolutionStarted(
+            ConfigurationResolutionStartedEvent {
+                id: read_event_id(body),
+                labels: extract_resolution_labels(body),
+            },
+        ))
+    }
+}
+
+pub struct ConfigurationResolutionFinishedDecoder;
+
+impl BodyDecoder for ConfigurationResolutionFinishedDecoder {
+    fn decode(&self, body: &[u8]) -> Result<DecodedEvent, ParseError> {
+        Ok(DecodedEvent::ConfigurationResolutionFinished(
+            ConfigurationResolutionFinishedEvent {
+                id: read_event_id(body),
+                labels: extract_resolution_labels(body),
+            },
+        ))
+    }
+}
+
+pub struct BuildWideConfigurationDependenciesDecoder;
+
+impl BodyDecoder for BuildWideConfigurationDependenciesDecoder {
+    fn decode(&self, body: &[u8]) -> Result<DecodedEvent, ParseError> {
+        let mut pos = 0;
+        let root_node_id = kryo::read_positive_varint_i64(body, &mut pos).ok();
+        let artifact_labels = extract_human_readable_strings(body)
+            .into_iter()
+            .filter(|value| looks_like_dependency_artifact_label(value))
+            .collect();
+
+        Ok(DecodedEvent::BuildWideConfigurationDependencies(
+            BuildWideConfigurationDependenciesEvent {
+                root_node_id,
+                artifact_labels,
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_labels_from_configuration_resolution_started_body() {
+        let data = hex::decode("0058b1263018de7781183a6275696c642d6c6f676963000601ce757e78a079c9")
+            .unwrap();
+
+        let decoder = ConfigurationResolutionStartedDecoder;
+        let decoded = decoder.decode(&data).unwrap();
+
+        match decoded {
+            DecodedEvent::ConfigurationResolutionStarted(event) => {
+                assert_ne!(event.id, 0);
+                assert_eq!(event.labels, vec![":build-logic"]);
+            }
+            other => panic!("expected ConfigurationResolutionStarted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extracts_labels_from_configuration_resolution_finished_body() {
+        let data = hex::decode(
+            "0852044f1ae519475c03143a6170703a6275696c64163a6c6973743a6275696c64203a7574696c69746965733a6275696c6400",
+        )
+        .unwrap();
+
+        let decoder = ConfigurationResolutionFinishedDecoder;
+        let decoded = decoder.decode(&data).unwrap();
+
+        match decoded {
+            DecodedEvent::ConfigurationResolutionFinished(event) => {
+                assert_ne!(event.id, 0);
+                assert_eq!(
+                    event.labels,
+                    vec![":app:build", ":list:build", ":utilities:build"]
+                );
+            }
+            other => panic!("expected ConfigurationResolutionFinished, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extracts_build_wide_artifact_labels() {
+        let data = hex::decode(
+            "de0b090428616e6e6f746174696f6e732d31332e302e6a617296016f72672e677261646c652e696e7465726e616c2e636f6d706f6e656e742e6c6f63616c2e6d6f64656c2e4f7061717565436f6d706f6e656e7441727469666163744964656e746966696572090430636f6d6d6f6e732d6c616e67332d332e32302e302e6a6172030904306b6f746c696e2d7374646c69622d322e332e32312e6a61720309043e6a756e69742d6a7570697465722d706172616d732d352e31322e312e6a6172030904306a756e69742d6a7570697465722d352e31322e312e6a6172030904286f70656e74657374346a2d312e332e302e6a6172030904086d61696e0309042e636f6d6d6f6e732d746578742d312e31352e302e6a617203090432617069677561726469616e2d6170692d312e312e322e6a6172030904426a756e69742d706c6174666f726d2d636f6d6d6f6e732d312e31322e312e6a6172030904386a756e69742d6a7570697465722d6170692d352e31322e312e6a617203030018617274696661637454797065066a6172001930636c617373706174682d656e7472792d736e617073686f740019126469726563746f7279",
+        )
+        .unwrap();
+
+        let decoder = BuildWideConfigurationDependenciesDecoder;
+        let decoded = decoder.decode(&data).unwrap();
+
+        match decoded {
+            DecodedEvent::BuildWideConfigurationDependencies(event) => {
+                assert_eq!(event.root_node_id, Some(1502));
+                assert!(
+                    event
+                        .artifact_labels
+                        .contains(&"annotations-13.0.jar".to_string())
+                );
+                assert!(
+                    event
+                        .artifact_labels
+                        .contains(&"junit-jupiter-api-5.12.1.jar".to_string())
+                );
+                assert!(!event.artifact_labels.contains(&"artifactType".to_string()));
+            }
+            other => panic!("expected BuildWideConfigurationDependencies, got {other:?}"),
+        }
+    }
+}

--- a/build-scan/lib/src/events/mod.rs
+++ b/build-scan/lib/src/events/mod.rs
@@ -18,6 +18,7 @@ pub mod build_finished;
 pub mod build_modes;
 pub mod build_requested_tasks;
 pub mod build_started;
+pub mod configuration_dependencies;
 pub mod daemon_state;
 pub mod encoding;
 pub mod file_ref_roots;
@@ -109,6 +110,9 @@ pub enum DecodedEvent {
     BuildCacheLocalStoreFinished(BuildCacheLocalStoreFinishedEvent),
     BuildCacheRemoteStoreStarted(BuildCacheRemoteStoreStartedEvent),
     BuildCacheRemoteStoreFinished(BuildCacheRemoteStoreFinishedEvent),
+    ConfigurationResolutionStarted(ConfigurationResolutionStartedEvent),
+    ConfigurationResolutionFinished(ConfigurationResolutionFinishedEvent),
+    BuildWideConfigurationDependencies(BuildWideConfigurationDependenciesEvent),
     Raw(RawEvent),
 }
 
@@ -579,6 +583,24 @@ pub struct BuildCacheRemoteStoreFinishedEvent {
 }
 
 #[derive(Debug, Clone)]
+pub struct ConfigurationResolutionStartedEvent {
+    pub id: i64,
+    pub labels: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigurationResolutionFinishedEvent {
+    pub id: i64,
+    pub labels: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BuildWideConfigurationDependenciesEvent {
+    pub root_node_id: Option<i64>,
+    pub artifact_labels: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct RawEvent {
     pub wire_id: u16,
     pub body: Vec<u8>,
@@ -731,6 +753,18 @@ impl DecoderRegistry {
                     has_remote_cache_location: true,
                 },
             ),
+        );
+        registry.register(
+            566,
+            Box::new(configuration_dependencies::ConfigurationResolutionFinishedDecoder),
+        );
+        registry.register(
+            567,
+            Box::new(configuration_dependencies::ConfigurationResolutionStartedDecoder),
+        );
+        registry.register(
+            1058,
+            Box::new(configuration_dependencies::BuildWideConfigurationDependenciesDecoder),
         );
 
         // Pack

--- a/build-scan/lib/src/models.rs
+++ b/build-scan/lib/src/models.rs
@@ -219,6 +219,10 @@ pub struct BuildScanPayload {
     pub planned_nodes: Vec<PlannedNodeData>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub transform_execution_requests: Vec<TransformExecutionRequestData>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub configuration_resolutions: Vec<ConfigurationResolutionData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_wide_configuration_dependencies: Option<BuildWideConfigurationDependenciesData>,
     pub raw_events: Vec<RawEventSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_registration_summary: Option<TaskRegistrationSummaryData>,
@@ -342,6 +346,23 @@ impl TaskOutcome {
 pub struct RawEventSummary {
     pub wire_id: u16,
     pub count: EventCount,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigurationResolutionData {
+    pub id: i64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub started_labels: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub finished_labels: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildWideConfigurationDependenciesData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_node_id: Option<i64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub artifact_labels: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/build-scan/server/db/migrations/src/BUILD.bazel
+++ b/build-scan/server/db/migrations/src/BUILD.bazel
@@ -12,6 +12,7 @@ rust_library(
         "sql/006_task_cache_operations.sql",
         "sql/007_add_duration_ms_to_cache_operations.sql",
         "sql/008_test_duration_and_failure.sql",
+        "sql/009_configuration_dependencies.sql",
     ],
     visibility = ["//visibility:public"],
     deps = ["@crates//:sqlx"],

--- a/build-scan/server/db/migrations/src/lib.rs
+++ b/build-scan/server/db/migrations/src/lib.rs
@@ -69,9 +69,15 @@ pub static MIGRATOR: Migrator = Migrator {
             version: 8,
             description: Cow::Borrowed("add test duration and failure details"),
             migration_type: MigrationType::Simple,
-            sql: Cow::Borrowed(include_str!(
-                "sql/008_test_duration_and_failure.sql"
-            )),
+            sql: Cow::Borrowed(include_str!("sql/008_test_duration_and_failure.sql")),
+            checksum: Cow::Borrowed(&[]),
+            no_tx: false,
+        },
+        Migration {
+            version: 9,
+            description: Cow::Borrowed("persist configuration dependencies"),
+            migration_type: MigrationType::Simple,
+            sql: Cow::Borrowed(include_str!("sql/009_configuration_dependencies.sql")),
             checksum: Cow::Borrowed(&[]),
             no_tx: false,
         },

--- a/build-scan/server/db/migrations/src/sql/009_configuration_dependencies.sql
+++ b/build-scan/server/db/migrations/src/sql/009_configuration_dependencies.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS configuration_dependencies (
+    scan_id TEXT NOT NULL REFERENCES build_scans(id),
+    configuration_id INTEGER NOT NULL,
+    display_name TEXT NOT NULL,
+    details_json TEXT NOT NULL,
+    started_labels_json TEXT NOT NULL,
+    finished_labels_json TEXT NOT NULL,
+    PRIMARY KEY (scan_id, configuration_id)
+);
+
+CREATE TABLE IF NOT EXISTS configuration_dependency_artifact_labels (
+    scan_id TEXT NOT NULL REFERENCES build_scans(id),
+    ordinal INTEGER NOT NULL,
+    label TEXT NOT NULL,
+    PRIMARY KEY (scan_id, ordinal)
+);

--- a/build-scan/server/db/src/lib.rs
+++ b/build-scan/server/db/src/lib.rs
@@ -50,7 +50,7 @@ struct TaskRow {
     origin_execution_time: Option<i64>,
     caching_disabled_reason: Option<String>,
     caching_disabled_explanation: Option<String>,
-    up_to_date_messages: Option<String>,  // JSON text, not Vec
+    up_to_date_messages: Option<String>, // JSON text, not Vec
     origin_build_invocation_id: Option<String>,
 }
 
@@ -78,10 +78,31 @@ struct TestRow {
     failure_stacktrace: Option<String>,
 }
 
+#[derive(Debug, sqlx::FromRow)]
+struct ConfigurationDependencyRow {
+    scan_id: String,
+    configuration_id: i64,
+    display_name: String,
+    details_json: String,
+    started_labels_json: String,
+    finished_labels_json: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct ConfigurationDependencyArtifactLabelRow {
+    scan_id: String,
+    ordinal: i64,
+    label: String,
+}
+
 fn parse_datetime(s: &str) -> Result<chrono::DateTime<Utc>> {
     NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
         .map(|dt| Utc.from_utc_datetime(&dt))
         .with_context(|| format!("invalid datetime '{s}'"))
+}
+
+fn parse_json_string_vec(value: &str, field_name: &str) -> Result<Vec<String>> {
+    serde_json::from_str(value).with_context(|| format!("invalid {field_name} JSON"))
 }
 
 impl TryFrom<BuildScanRow> for domain::BuildScan {
@@ -220,10 +241,9 @@ impl From<&domain::Task> for TaskRow {
             origin_execution_time: task.origin_execution_time.map(|d| d.0),
             caching_disabled_reason: task.caching_disabled_reason.clone(),
             caching_disabled_explanation: task.caching_disabled_explanation.clone(),
-            up_to_date_messages: task
-                .up_to_date_messages
-                .as_ref()
-                .map(|msgs| serde_json::to_string(msgs).expect("failed to serialize up_to_date_messages")),
+            up_to_date_messages: task.up_to_date_messages.as_ref().map(|msgs| {
+                serde_json::to_string(msgs).expect("failed to serialize up_to_date_messages")
+            }),
             origin_build_invocation_id: task.origin_build_invocation_id.clone(),
         }
     }
@@ -270,6 +290,76 @@ impl From<&domain::Test> for TestRow {
             duration_ms: test.duration_ms.map(|d| d.0),
             failure_message: test.failure_message.clone(),
             failure_stacktrace: test.failure_stacktrace.clone(),
+        }
+    }
+}
+
+impl TryFrom<ConfigurationDependencyRow> for domain::PersistedConfigurationDependency {
+    type Error = anyhow::Error;
+
+    fn try_from(row: ConfigurationDependencyRow) -> Result<Self, Self::Error> {
+        let scan_id = domain::BuildScanId(
+            uuid::Uuid::parse_str(&row.scan_id)
+                .with_context(|| format!("invalid scan_id '{}'", row.scan_id))?,
+        );
+
+        Ok(domain::PersistedConfigurationDependency {
+            scan_id,
+            configuration_id: row.configuration_id,
+            display_name: row.display_name,
+            details: parse_json_string_vec(&row.details_json, "details_json")?,
+            started_labels: parse_json_string_vec(&row.started_labels_json, "started_labels_json")?,
+            finished_labels: parse_json_string_vec(
+                &row.finished_labels_json,
+                "finished_labels_json",
+            )?,
+        })
+    }
+}
+
+impl From<&domain::PersistedConfigurationDependency> for ConfigurationDependencyRow {
+    fn from(dependency: &domain::PersistedConfigurationDependency) -> Self {
+        Self {
+            scan_id: dependency.scan_id.0.to_string(),
+            configuration_id: dependency.configuration_id,
+            display_name: dependency.display_name.clone(),
+            details_json: serde_json::to_string(&dependency.details)
+                .expect("failed to serialize details_json"),
+            started_labels_json: serde_json::to_string(&dependency.started_labels)
+                .expect("failed to serialize started_labels_json"),
+            finished_labels_json: serde_json::to_string(&dependency.finished_labels)
+                .expect("failed to serialize finished_labels_json"),
+        }
+    }
+}
+
+impl TryFrom<ConfigurationDependencyArtifactLabelRow>
+    for domain::PersistedConfigurationDependencyArtifactLabel
+{
+    type Error = anyhow::Error;
+
+    fn try_from(row: ConfigurationDependencyArtifactLabelRow) -> Result<Self, Self::Error> {
+        let scan_id = domain::BuildScanId(
+            uuid::Uuid::parse_str(&row.scan_id)
+                .with_context(|| format!("invalid scan_id '{}'", row.scan_id))?,
+        );
+
+        Ok(domain::PersistedConfigurationDependencyArtifactLabel {
+            scan_id,
+            ordinal: row.ordinal,
+            label: row.label,
+        })
+    }
+}
+
+impl From<&domain::PersistedConfigurationDependencyArtifactLabel>
+    for ConfigurationDependencyArtifactLabelRow
+{
+    fn from(label: &domain::PersistedConfigurationDependencyArtifactLabel) -> Self {
+        Self {
+            scan_id: label.scan_id.0.to_string(),
+            ordinal: label.ordinal,
+            label: label.label.clone(),
         }
     }
 }
@@ -506,6 +596,100 @@ pub async fn insert_test<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite>>(
     .execute(executor)
     .await?;
     Ok(())
+}
+
+pub async fn insert_configuration_dependency<'c, E: sqlx::Executor<'c, Database = sqlx::Sqlite>>(
+    executor: E,
+    dependency: &domain::PersistedConfigurationDependency,
+) -> Result<()> {
+    let row = ConfigurationDependencyRow::from(dependency);
+
+    sqlx::query(
+        "INSERT INTO configuration_dependencies (scan_id, configuration_id, display_name, details_json, started_labels_json, finished_labels_json) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&row.scan_id)
+    .bind(row.configuration_id)
+    .bind(&row.display_name)
+    .bind(&row.details_json)
+    .bind(&row.started_labels_json)
+    .bind(&row.finished_labels_json)
+    .execute(executor)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn list_configuration_dependencies(
+    pool: &SqlitePool,
+    scan_id: &str,
+) -> Result<Vec<domain::PersistedConfigurationDependency>> {
+    let rows = sqlx::query_as::<_, ConfigurationDependencyRow>(
+        "SELECT scan_id, configuration_id, display_name, details_json, started_labels_json, finished_labels_json \
+         FROM configuration_dependencies WHERE scan_id = ? ORDER BY configuration_id",
+    )
+    .bind(scan_id)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(domain::PersistedConfigurationDependency::try_from)
+        .collect::<Result<Vec<_>>>()
+}
+
+pub async fn get_configuration_dependency(
+    pool: &SqlitePool,
+    scan_id: &str,
+    configuration_id: i64,
+) -> Result<Option<domain::PersistedConfigurationDependency>> {
+    let row = sqlx::query_as::<_, ConfigurationDependencyRow>(
+        "SELECT scan_id, configuration_id, display_name, details_json, started_labels_json, finished_labels_json \
+         FROM configuration_dependencies WHERE scan_id = ? AND configuration_id = ?",
+    )
+    .bind(scan_id)
+    .bind(configuration_id)
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(domain::PersistedConfigurationDependency::try_from)
+        .transpose()
+}
+
+pub async fn insert_configuration_dependency_artifact_label<
+    'c,
+    E: sqlx::Executor<'c, Database = sqlx::Sqlite>,
+>(
+    executor: E,
+    label: &domain::PersistedConfigurationDependencyArtifactLabel,
+) -> Result<()> {
+    let row = ConfigurationDependencyArtifactLabelRow::from(label);
+
+    sqlx::query(
+        "INSERT INTO configuration_dependency_artifact_labels (scan_id, ordinal, label) VALUES (?, ?, ?)",
+    )
+    .bind(&row.scan_id)
+    .bind(row.ordinal)
+    .bind(&row.label)
+    .execute(executor)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn list_configuration_dependency_artifact_labels(
+    pool: &SqlitePool,
+    scan_id: &str,
+) -> Result<Vec<domain::PersistedConfigurationDependencyArtifactLabel>> {
+    let rows = sqlx::query_as::<_, ConfigurationDependencyArtifactLabelRow>(
+        "SELECT scan_id, ordinal, label FROM configuration_dependency_artifact_labels WHERE scan_id = ? ORDER BY ordinal",
+    )
+    .bind(scan_id)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(domain::PersistedConfigurationDependencyArtifactLabel::try_from)
+        .collect::<Result<Vec<_>>>()
 }
 
 pub async fn list_tests(

--- a/build-scan/server/domain/src/lib.rs
+++ b/build-scan/server/domain/src/lib.rs
@@ -440,3 +440,45 @@ pub struct CacheOperation {
     pub cache_key: Option<String>,
     pub duration_ms: Option<Duration>,
 }
+
+#[derive(Debug, Clone)]
+pub struct ConfigurationDependency {
+    pub id: String,
+    pub display_name: String,
+    pub details: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistedConfigurationDependency {
+    pub scan_id: BuildScanId,
+    pub configuration_id: i64,
+    pub display_name: String,
+    pub details: Vec<String>,
+    pub started_labels: Vec<String>,
+    pub finished_labels: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistedConfigurationDependencyArtifactLabel {
+    pub scan_id: BuildScanId,
+    pub ordinal: i64,
+    pub label: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigurationDependencyGraph {
+    pub nodes: Vec<ConfigurationDependencyNode>,
+    pub edges: Vec<ConfigurationDependencyEdge>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigurationDependencyNode {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigurationDependencyEdge {
+    pub source_id: String,
+    pub target_id: String,
+}

--- a/build-scan/server/graphql/src/lib.rs
+++ b/build-scan/server/graphql/src/lib.rs
@@ -108,6 +108,36 @@ impl BuildScan {
         Ok(count)
     }
 
+    async fn configuration_dependencies(
+        &self,
+        context: &Context,
+    ) -> FieldResult<Vec<ConfigurationDependency>> {
+        let configurations = context
+            .service
+            .get_configuration_dependencies(&self.scan.id.0.to_string())
+            .await
+            .map_err(|e| FieldError::from(e.to_string()))?;
+
+        Ok(configurations
+            .into_iter()
+            .map(|configuration| ConfigurationDependency { configuration })
+            .collect())
+    }
+
+    async fn configuration_dependency_graph(
+        &self,
+        context: &Context,
+        configuration_id: String,
+    ) -> FieldResult<Option<ConfigurationDependencyGraph>> {
+        let graph = context
+            .service
+            .get_configuration_dependency_graph(&self.scan.id.0.to_string(), &configuration_id)
+            .await
+            .map_err(|e| FieldError::from(e.to_string()))?;
+
+        Ok(graph.map(|graph| ConfigurationDependencyGraph { graph }))
+    }
+
     async fn tasks(
         &self,
         context: &Context,
@@ -235,6 +265,80 @@ impl BuildScan {
 
 pub struct Task {
     pub task: domain::Task,
+}
+
+pub struct ConfigurationDependency {
+    pub configuration: domain::ConfigurationDependency,
+}
+
+#[graphql_object(context = Context)]
+impl ConfigurationDependency {
+    fn id(&self) -> &str {
+        &self.configuration.id
+    }
+
+    fn display_name(&self) -> &str {
+        &self.configuration.display_name
+    }
+
+    fn details(&self) -> &Vec<String> {
+        &self.configuration.details
+    }
+}
+
+pub struct ConfigurationDependencyGraph {
+    pub graph: domain::ConfigurationDependencyGraph,
+}
+
+#[graphql_object(context = Context)]
+impl ConfigurationDependencyGraph {
+    fn nodes(&self) -> Vec<ConfigurationDependencyNode> {
+        self.graph
+            .nodes
+            .iter()
+            .cloned()
+            .map(|node| ConfigurationDependencyNode { node })
+            .collect()
+    }
+
+    fn edges(&self) -> Vec<ConfigurationDependencyEdge> {
+        self.graph
+            .edges
+            .iter()
+            .cloned()
+            .map(|edge| ConfigurationDependencyEdge { edge })
+            .collect()
+    }
+}
+
+pub struct ConfigurationDependencyNode {
+    pub node: domain::ConfigurationDependencyNode,
+}
+
+#[graphql_object(context = Context)]
+impl ConfigurationDependencyNode {
+    fn id(&self) -> &str {
+        &self.node.id
+    }
+
+    fn label(&self) -> &str {
+        &self.node.label
+    }
+}
+
+pub struct ConfigurationDependencyEdge {
+    pub edge: domain::ConfigurationDependencyEdge,
+}
+
+#[graphql_object(context = Context)]
+impl ConfigurationDependencyEdge {
+    fn source_id(&self) -> &str {
+        &self.edge.source_id
+    }
+
+    fn target_id(&self) -> &str {
+        &self.edge.target_id
+    }
 }
 
 #[graphql_object(context = Context, impl = NodeValue)]

--- a/build-scan/server/service/src/BUILD.bazel
+++ b/build-scan/server/service/src/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "service",
@@ -16,4 +16,9 @@ rust_library(
         "@crates//:tracing",
         "@crates//:uuid",
     ],
+)
+
+rust_test(
+    name = "service_test",
+    crate = ":service",
 )

--- a/build-scan/server/service/src/lib.rs
+++ b/build-scan/server/service/src/lib.rs
@@ -48,6 +48,89 @@ fn map_task_outcome(outcome: &models::TaskOutcome) -> domain::TaskOutcome {
     }
 }
 
+fn push_unique_string(values: &mut Vec<String>, value: String) {
+    if !value.is_empty() && !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn configuration_labels(resolution: &models::ConfigurationResolutionData) -> Vec<String> {
+    let mut labels = Vec::new();
+
+    for label in &resolution.finished_labels {
+        push_unique_string(&mut labels, label.clone());
+    }
+    for label in &resolution.started_labels {
+        push_unique_string(&mut labels, label.clone());
+    }
+
+    labels
+}
+
+fn build_persisted_configuration_dependency(
+    scan_id: domain::BuildScanId,
+    resolution: &models::ConfigurationResolutionData,
+) -> domain::PersistedConfigurationDependency {
+    let labels = configuration_labels(resolution);
+    let display_name = labels
+        .first()
+        .cloned()
+        .unwrap_or_else(|| format!("Resolution {}", resolution.id));
+    let details = labels
+        .into_iter()
+        .filter(|label| label != &display_name)
+        .collect();
+
+    domain::PersistedConfigurationDependency {
+        scan_id,
+        configuration_id: resolution.id,
+        display_name,
+        details,
+        started_labels: resolution.started_labels.clone(),
+        finished_labels: resolution.finished_labels.clone(),
+    }
+}
+
+fn build_configuration_dependency_graph(
+    configuration: &domain::ConfigurationDependency,
+    dependency_labels: Vec<String>,
+) -> Option<domain::ConfigurationDependencyGraph> {
+    if dependency_labels.is_empty() {
+        return None;
+    }
+
+    let root_id = format!("configuration:{}", configuration.id);
+    let mut nodes = vec![domain::ConfigurationDependencyNode {
+        id: root_id.clone(),
+        label: configuration.display_name.clone(),
+    }];
+    let mut edges = Vec::new();
+
+    for (index, label) in dependency_labels.into_iter().take(48).enumerate() {
+        let node_id = format!("dependency:{}:{}", configuration.id, index);
+        nodes.push(domain::ConfigurationDependencyNode {
+            id: node_id.clone(),
+            label,
+        });
+        edges.push(domain::ConfigurationDependencyEdge {
+            source_id: root_id.clone(),
+            target_id: node_id,
+        });
+    }
+
+    Some(domain::ConfigurationDependencyGraph { nodes, edges })
+}
+
+fn map_configuration_dependency(
+    dependency: domain::PersistedConfigurationDependency,
+) -> domain::ConfigurationDependency {
+    domain::ConfigurationDependency {
+        id: dependency.configuration_id.to_string(),
+        display_name: dependency.display_name,
+        details: dependency.details,
+    }
+}
+
 pub struct BuildScanService {
     pool: SqlitePool,
 }
@@ -129,6 +212,7 @@ impl BuildScanService {
                     .build()
                     .map_err(|e| anyhow::anyhow!(e))
                     .context("failed to build BuildScan")?;
+                let persisted_scan_id = domain::BuildScanId(scan_uuid);
 
                 let mut tx = self
                     .pool
@@ -209,9 +293,7 @@ impl BuildScanService {
                                 cache_op.stored.unwrap_or(false)
                             }
                             models::CacheOperationType::Pack
-                            | models::CacheOperationType::Unpack => {
-                                cache_op.failure_id.is_none()
-                            }
+                            | models::CacheOperationType::Unpack => cache_op.failure_id.is_none(),
                         };
                         let domain_op = domain::CacheOperation {
                             id: domain::CacheOperationId(Uuid::new_v4()),
@@ -222,9 +304,7 @@ impl BuildScanService {
                                 .archive_size
                                 .map(|s| domain::ArchiveSize(s.as_i64())),
                             cache_key: cache_op.cache_key.clone(),
-                            duration_ms: cache_op
-                                .duration_ms
-                                .map(|d| domain::Duration(d.as_i64())),
+                            duration_ms: cache_op.duration_ms.map(|d| domain::Duration(d.as_i64())),
                         };
                         db::insert_cache_operation(&mut *tx, &domain_op)
                             .await
@@ -268,9 +348,51 @@ impl BuildScanService {
                         .with_context(|| format!("failed to store test {}", test.class_name))?;
                 }
 
+                let configuration_dependency_count = payload.configuration_resolutions.len();
+                for resolution in &payload.configuration_resolutions {
+                    let dependency = build_persisted_configuration_dependency(
+                        persisted_scan_id.clone(),
+                        resolution,
+                    );
+
+                    db::insert_configuration_dependency(&mut *tx, &dependency)
+                        .await
+                        .with_context(|| {
+                            format!("failed to store configuration dependency {}", resolution.id)
+                        })?;
+                }
+
+                let artifact_label_count =
+                    if let Some(dependencies) = &payload.build_wide_configuration_dependencies {
+                        for (ordinal, label) in dependencies.artifact_labels.iter().enumerate() {
+                            let artifact_label =
+                                domain::PersistedConfigurationDependencyArtifactLabel {
+                                    scan_id: persisted_scan_id.clone(),
+                                    ordinal: ordinal as i64,
+                                    label: label.clone(),
+                                };
+
+                            db::insert_configuration_dependency_artifact_label(
+                                &mut *tx,
+                                &artifact_label,
+                            )
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "failed to store configuration dependency artifact label {}",
+                                    ordinal
+                                )
+                            })?;
+                        }
+
+                        dependencies.artifact_labels.len()
+                    } else {
+                        0
+                    };
+
                 tx.commit().await.context("failed to commit transaction")?;
 
-                info!(scan_id = %scan_id, task_count = task_count, test_count = test_count, "Stored build scan successfully");
+                info!(scan_id = %scan_id, task_count = task_count, test_count = test_count, configuration_dependency_count = configuration_dependency_count, artifact_label_count = artifact_label_count, "Stored build scan successfully");
             }
         }
 
@@ -279,6 +401,51 @@ impl BuildScanService {
 
     pub async fn get_build_scan(&self, id: &str) -> Result<Option<domain::BuildScan>> {
         db::get_build_scan(&self.pool, id).await
+    }
+
+    pub async fn get_configuration_dependencies(
+        &self,
+        scan_id: &str,
+    ) -> Result<Vec<domain::ConfigurationDependency>> {
+        Ok(db::list_configuration_dependencies(&self.pool, scan_id)
+            .await?
+            .into_iter()
+            .map(map_configuration_dependency)
+            .collect())
+    }
+
+    pub async fn get_configuration_dependency_graph(
+        &self,
+        scan_id: &str,
+        configuration_id: &str,
+    ) -> Result<Option<domain::ConfigurationDependencyGraph>> {
+        let Ok(configuration_id) = configuration_id.parse::<i64>() else {
+            return Ok(None);
+        };
+
+        let Some(configuration) =
+            db::get_configuration_dependency(&self.pool, scan_id, configuration_id).await?
+        else {
+            return Ok(None);
+        };
+
+        let artifact_labels =
+            db::list_configuration_dependency_artifact_labels(&self.pool, scan_id)
+                .await?
+                .into_iter()
+                .map(|label| label.label)
+                .collect::<Vec<_>>();
+        let configuration = map_configuration_dependency(configuration.clone());
+        let dependency_labels = if artifact_labels.is_empty() {
+            configuration.details.clone()
+        } else {
+            artifact_labels
+        };
+
+        Ok(build_configuration_dependency_graph(
+            &configuration,
+            dependency_labels,
+        ))
     }
 
     pub async fn list_build_scans(
@@ -337,5 +504,120 @@ impl BuildScanService {
         task_id: &str,
     ) -> Result<Vec<domain::CacheOperation>> {
         db::list_cache_operations(&self.pool, task_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn persisted_configuration_dependency(
+        configuration_id: i64,
+        display_name: &str,
+        details: &[&str],
+    ) -> domain::PersistedConfigurationDependency {
+        domain::PersistedConfigurationDependency {
+            scan_id: domain::BuildScanId(Uuid::nil()),
+            configuration_id,
+            display_name: display_name.to_string(),
+            details: details.iter().map(|detail| detail.to_string()).collect(),
+            started_labels: Vec::new(),
+            finished_labels: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn configuration_dependency_graph_uses_persisted_artifact_labels() {
+        let configuration = map_configuration_dependency(persisted_configuration_dependency(
+            6648731359144961106,
+            ":app:build",
+            &[":list:build"],
+        ));
+
+        let graph = build_configuration_dependency_graph(
+            &configuration,
+            vec![
+                "junit-jupiter-api-5.12.1.jar".to_string(),
+                "hamcrest-3.0.jar".to_string(),
+            ],
+        )
+        .expect("graph should be built");
+
+        assert_eq!(graph.nodes[0].id, "configuration:6648731359144961106");
+        assert_eq!(graph.nodes[0].label, ":app:build");
+        assert_eq!(graph.nodes[1].label, "junit-jupiter-api-5.12.1.jar");
+        assert_eq!(graph.nodes[2].label, "hamcrest-3.0.jar");
+        assert_eq!(
+            graph.edges[0].source_id,
+            "configuration:6648731359144961106"
+        );
+        assert_eq!(graph.edges[0].target_id, "dependency:6648731359144961106:0");
+    }
+
+    #[test]
+    fn persisted_configuration_dependency_keeps_raw_labels_and_derives_summary() {
+        let dependency = build_persisted_configuration_dependency(
+            domain::BuildScanId(Uuid::nil()),
+            &models::ConfigurationResolutionData {
+                id: 19,
+                started_labels: vec![
+                    ":app:compileClasspath".to_string(),
+                    "shared-label".to_string(),
+                ],
+                finished_labels: vec![
+                    ":app:runtimeClasspath".to_string(),
+                    "shared-label".to_string(),
+                ],
+            },
+        );
+
+        assert_eq!(dependency.configuration_id, 19);
+        assert_eq!(dependency.display_name, ":app:runtimeClasspath");
+        assert_eq!(
+            dependency.details,
+            vec![
+                "shared-label".to_string(),
+                ":app:compileClasspath".to_string()
+            ]
+        );
+        assert_eq!(
+            dependency.started_labels,
+            vec![
+                ":app:compileClasspath".to_string(),
+                "shared-label".to_string(),
+            ]
+        );
+        assert_eq!(
+            dependency.finished_labels,
+            vec![
+                ":app:runtimeClasspath".to_string(),
+                "shared-label".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn configuration_dependency_graph_falls_back_to_persisted_details() {
+        let configuration = map_configuration_dependency(persisted_configuration_dependency(
+            77,
+            ":app:build",
+            &[":list:build", ":utilities:build"],
+        ));
+
+        let graph =
+            build_configuration_dependency_graph(&configuration, configuration.details.clone())
+                .expect("graph should be built");
+
+        assert_eq!(graph.nodes.len(), 3);
+        assert_eq!(graph.nodes[1].label, ":list:build");
+        assert_eq!(graph.nodes[2].label, ":utilities:build");
+    }
+
+    #[test]
+    fn configuration_dependency_graph_is_absent_without_any_persisted_labels() {
+        let configuration =
+            map_configuration_dependency(persisted_configuration_dependency(77, ":app:build", &[]));
+
+        assert!(build_configuration_dependency_graph(&configuration, Vec::new()).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- extract only the configuration-dependency-related changes from the mixed `task-dependency-graph-panzoom` worktree into a dedicated branch
- preserve the parser, persistence, GraphQL, and Angular tab work for configuration dependencies while excluding task graph and panzoom-specific files
- keep this PR as a draft because the current implementation still appears to use the wrong dependency concept in places (for example task-like labels such as `:app:build`), even though public Gradle scans were verified to expose real configuration names like `runtimeClasspath` and `compileClasspath`

## Notes
- this branch is intentionally scoped to the extracted subset only
- task graph / panzoom work was left out
- verification was run in the extracted worktree: `bazel run gazelle`, `bazel run //tools/format`, `aspect lint //...`, `aspect test //...`, `aspect build //...`

## Follow-up
- replace the current heuristic labeling with real configuration identity derived from the build scan payload