### PR TITLE
perf: fix tasks tab performance for large scans

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.spec.ts
@@ -156,6 +156,47 @@ describe("ScanTasksTabComponent", () => {
     expect(fixture.nativeElement.querySelector("app-tasks-table")).toBeTruthy();
   });
 
+  it("hides the dependency graph by default for very large scans", () => {
+    const largeFixture = TestBed.createComponent(ScanTasksTabComponent);
+    largeFixture.componentRef.setInput("scanId", "123");
+    largeFixture.componentRef.setInput("taskCount", 1000);
+    largeFixture.detectChanges();
+
+    const pending = controller.expectOne("GetScanTasks");
+    pending.flushData({
+      buildScan: buildTaskScan([buildTaskEdge()], {
+        hasNextPage: false,
+        endCursor: null,
+      }),
+    });
+    largeFixture.detectChanges();
+
+    expect(
+      largeFixture.nativeElement.querySelector("app-task-dependency-graph"),
+    ).toBeNull();
+    expect(largeFixture.nativeElement.textContent).toContain(
+      "Task dependency graph hidden",
+    );
+
+    const buttons = Array.from(
+      (largeFixture.nativeElement as HTMLElement).querySelectorAll("button"),
+    ) as HTMLButtonElement[];
+
+    const button = buttons.find((candidate) =>
+      candidate.textContent?.includes("Render graph anyway"),
+    );
+
+    expect(button).toBeTruthy();
+    button?.click();
+    largeFixture.detectChanges();
+
+    expect(
+      largeFixture.nativeElement.querySelector("app-task-dependency-graph"),
+    ).toBeTruthy();
+
+    largeFixture.destroy();
+  });
+
   it("skips querying when the overview already reports zero tasks", () => {
     const zeroFixture = TestBed.createComponent(ScanTasksTabComponent);
     zeroFixture.componentRef.setInput("scanId", "123");

--- a/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.spec.ts
@@ -51,17 +51,22 @@ describe("ScanTasksTabComponent", () => {
       imports: [ApolloTestingModule, ScanTasksTabComponent],
     });
     controller = TestBed.inject(ApolloTestingController);
-    fixture = TestBed.createComponent(ScanTasksTabComponent);
-    fixture.componentRef.setInput("scanId", "123");
-    fixture.componentRef.setInput("taskCount", 1);
-    fixture.detectChanges();
   });
 
+  function createFixture(taskCount = 1) {
+    fixture = TestBed.createComponent(ScanTasksTabComponent);
+    fixture.componentRef.setInput("scanId", "123");
+    fixture.componentRef.setInput("taskCount", taskCount);
+    fixture.detectChanges();
+    return fixture;
+  }
+
   afterEach(() => {
-    fixture.destroy();
+    fixture?.destroy();
   });
 
   it("shows a loading state before the first result and then renders the task views", () => {
+    createFixture();
     const pending = controller.expectOne("GetScanTasks");
     const queryText = pending.operation.query.loc?.source.body ?? "";
     expect(pending.operation.variables).toEqual({
@@ -94,6 +99,7 @@ describe("ScanTasksTabComponent", () => {
   });
 
   it("passes per-task dependencies through to the task timeline", () => {
+    createFixture();
     const pending = controller.expectOne("GetScanTasks");
 
     pending.flushData({
@@ -114,6 +120,7 @@ describe("ScanTasksTabComponent", () => {
   });
 
   it("continues loading additional task pages when pageInfo hasNextPage is true", async () => {
+    createFixture();
     const first = controller.expectOne("GetScanTasks");
     first.flushData({
       buildScan: buildTaskScan([buildTaskEdge()], {
@@ -157,10 +164,7 @@ describe("ScanTasksTabComponent", () => {
   });
 
   it("hides the dependency graph by default for very large scans", () => {
-    const largeFixture = TestBed.createComponent(ScanTasksTabComponent);
-    largeFixture.componentRef.setInput("scanId", "123");
-    largeFixture.componentRef.setInput("taskCount", 1000);
-    largeFixture.detectChanges();
+    const largeFixture = createFixture(1000);
 
     const pending = controller.expectOne("GetScanTasks");
     pending.flushData({
@@ -198,15 +202,8 @@ describe("ScanTasksTabComponent", () => {
   });
 
   it("skips querying when the overview already reports zero tasks", () => {
-    const zeroFixture = TestBed.createComponent(ScanTasksTabComponent);
-    zeroFixture.componentRef.setInput("scanId", "123");
-    zeroFixture.componentRef.setInput("taskCount", 0);
+    const zeroFixture = createFixture(0);
     zeroFixture.detectChanges();
-
-    controller
-      .expectOne("GetScanTasks")
-      .flushData({ buildScan: buildTaskScan() });
-    fixture.detectChanges();
 
     expect(controller.match("GetScanTasks")).toHaveLength(0);
     expect(zeroFixture.nativeElement.textContent).toContain(

--- a/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   DestroyRef,
   inject,
   input,
@@ -72,6 +73,8 @@ interface PartialTaskScan {
   };
 }
 
+const LARGE_GRAPH_TASK_THRESHOLD = 500;
+
 const GET_SCAN_TASKS = gql`
   query GetScanTasks($id: ID!, $firstTasks: Int!, $afterTasks: String) {
     buildScan(id: $id) {
@@ -124,21 +127,46 @@ const GET_SCAN_TASKS = gql`
     <div class="space-y-6">
       <h2 class="text-2xl font-bold">Tasks</h2>
 
-      @if (loading() && taskEdges().length === 0) {
+      @if (loading()) {
         <div
           class="rounded-md border border-base-300 bg-base-200 p-4 text-sm opacity-70"
         >
-          Loading tasks…
+          @if (taskEdges().length === 0) {
+            Loading tasks…
+          } @else {
+            Loading remaining tasks ({{ taskEdges().length }} of
+            {{ taskCount() }})…
+          }
         </div>
-      }
-
-      @if (taskEdges().length > 0) {
+      } @else if (taskEdges().length > 0) {
         <app-cache-breakdown
           [taskEdges]="taskEdges()"
           [taskCount]="taskCount()"
           [loading]="loading()"
         />
-        <app-task-dependency-graph [taskEdges]="taskEdges()" />
+
+        @if (showDependencyGraph()) {
+          <app-task-dependency-graph [taskEdges]="taskEdges()" />
+        } @else if (hasLargeTaskGraph()) {
+          <div
+            class="rounded-md border border-base-300 bg-base-200 p-4 text-sm"
+          >
+            <div class="font-semibold">Task dependency graph hidden</div>
+            <p class="mt-1 opacity-70">
+              This scan has {{ taskCount() }} tasks. Rendering the full
+              dependency graph for very large scans can stall the browser, so
+              the graph is hidden by default.
+            </p>
+            <button
+              class="btn btn-sm mt-3"
+              type="button"
+              (click)="renderLargeGraph.set(true)"
+            >
+              Render graph anyway
+            </button>
+          </div>
+        }
+
         <app-tasks-table [taskEdges]="taskEdges()" [taskCount]="taskCount()" />
       } @else if (!loading()) {
         <div
@@ -160,6 +188,13 @@ export class ScanTasksTabComponent implements OnInit {
 
   taskEdges = signal<TaskEdge[]>([]);
   loading = signal(true);
+  renderLargeGraph = signal(false);
+  hasLargeTaskGraph = computed(
+    () => this.taskCount() > LARGE_GRAPH_TASK_THRESHOLD,
+  );
+  showDependencyGraph = computed(
+    () => !this.hasLargeTaskGraph() || this.renderLargeGraph(),
+  );
 
   private loadRemainingPages(
     queryRef: QueryRef<GetScanTasksData, GetScanTasksVariables>,
@@ -193,6 +228,7 @@ export class ScanTasksTabComponent implements OnInit {
       .pipe(
         switchMap((id) => {
           this.taskEdges.set([]);
+          this.renderLargeGraph.set(false);
           if (this.taskCount() === 0) {
             this.loading.set(false);
             return EMPTY;

--- a/build-scan/server/db/src/lib.rs
+++ b/build-scan/server/db/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use chrono::{NaiveDateTime, TimeZone, Utc};
-use sqlx::{SqlitePool, sqlite::SqliteConnectOptions, sqlite::SqlitePoolOptions};
+use sqlx::{QueryBuilder, SqlitePool, sqlite::SqliteConnectOptions, sqlite::SqlitePoolOptions};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
@@ -494,19 +494,40 @@ pub async fn list_task_dependency_map_for_scan(
     .fetch_all(pool)
     .await?;
 
-    let mut map = BTreeMap::<uuid::Uuid, Vec<domain::TaskId>>::new();
-    for row in rows {
-        let task_id = uuid::Uuid::parse_str(&row.task_id)
-            .with_context(|| format!("invalid task_id '{}'", row.task_id))?;
-        let dependency_task_id = uuid::Uuid::parse_str(&row.dependency_task_id)
-            .with_context(|| format!("invalid dependency_task_id '{}'", row.dependency_task_id))?;
+    map_task_dependency_rows(rows)
+}
 
-        map.entry(task_id)
-            .or_default()
-            .push(domain::TaskId(dependency_task_id));
+pub async fn list_task_dependency_map_for_tasks(
+    pool: &SqlitePool,
+    scan_id: &str,
+    task_ids: &[String],
+) -> Result<BTreeMap<uuid::Uuid, Vec<domain::TaskId>>> {
+    if task_ids.is_empty() {
+        return Ok(BTreeMap::new());
     }
 
-    Ok(map)
+    let mut query_builder = QueryBuilder::<sqlx::Sqlite>::new(
+        "SELECT td.task_id, td.dependency_task_id \
+         FROM task_dependencies td \
+         JOIN tasks task ON task.id = td.task_id \
+         WHERE task.scan_id = ",
+    );
+    query_builder.push_bind(scan_id);
+    query_builder.push(" AND td.task_id IN (");
+
+    let mut separated = query_builder.separated(", ");
+    for task_id in task_ids {
+        separated.push_bind(task_id);
+    }
+    separated.push_unseparated(")");
+    query_builder.push(" ORDER BY td.task_id, td.dependency_task_id");
+
+    let rows = query_builder
+        .build_query_as::<TaskDependencyRow>()
+        .fetch_all(pool)
+        .await?;
+
+    map_task_dependency_rows(rows)
 }
 
 pub async fn count_tasks(pool: &SqlitePool, scan_id: &str) -> Result<i64> {
@@ -685,4 +706,59 @@ pub async fn list_cache_operations(
     rows.into_iter()
         .map(domain::CacheOperation::try_from)
         .collect::<Result<Vec<_>>>()
+}
+
+pub async fn list_cache_operations_for_tasks(
+    pool: &SqlitePool,
+    task_ids: &[String],
+) -> Result<BTreeMap<uuid::Uuid, Vec<domain::CacheOperation>>> {
+    if task_ids.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let mut query_builder = QueryBuilder::<sqlx::Sqlite>::new(
+        "SELECT id, task_id, operation_type, succeeded, archive_size, cache_key, duration_ms \
+         FROM task_cache_operations WHERE task_id IN (",
+    );
+
+    let mut separated = query_builder.separated(", ");
+    for task_id in task_ids {
+        separated.push_bind(task_id);
+    }
+    separated.push_unseparated(")");
+    query_builder.push(" ORDER BY task_id, rowid");
+
+    let rows = query_builder
+        .build_query_as::<CacheOperationRow>()
+        .fetch_all(pool)
+        .await?;
+
+    let mut operations_by_task_id = BTreeMap::<uuid::Uuid, Vec<domain::CacheOperation>>::new();
+    for row in rows {
+        let operation = domain::CacheOperation::try_from(row)?;
+        operations_by_task_id
+            .entry(operation.task_id.0)
+            .or_default()
+            .push(operation);
+    }
+
+    Ok(operations_by_task_id)
+}
+
+fn map_task_dependency_rows(
+    rows: Vec<TaskDependencyRow>,
+) -> Result<BTreeMap<uuid::Uuid, Vec<domain::TaskId>>> {
+    let mut map = BTreeMap::<uuid::Uuid, Vec<domain::TaskId>>::new();
+    for row in rows {
+        let task_id = uuid::Uuid::parse_str(&row.task_id)
+            .with_context(|| format!("invalid task_id '{}'", row.task_id))?;
+        let dependency_task_id = uuid::Uuid::parse_str(&row.dependency_task_id)
+            .with_context(|| format!("invalid dependency_task_id '{}'", row.dependency_task_id))?;
+
+        map.entry(task_id)
+            .or_default()
+            .push(domain::TaskId(dependency_task_id));
+    }
+
+    Ok(map)
 }

--- a/build-scan/server/graphql/src/lib.rs
+++ b/build-scan/server/graphql/src/lib.rs
@@ -138,13 +138,26 @@ impl BuildScan {
             .last()
             .map(|t| Cursor::new(t.id.0.to_string()).encode());
 
+        let task_ids = tasks
+            .iter()
+            .map(|task| task.id.0.to_string())
+            .collect::<Vec<_>>();
+        let mut cache_operations_by_task_id = context
+            .service
+            .list_cache_operations_for_tasks(&task_ids)
+            .await
+            .map_err(|e| FieldError::from(e.to_string()))?;
+
         let edges: Vec<TaskEdge> = tasks
             .into_iter()
             .map(|t| {
                 let cursor = Cursor::new(t.id.0.to_string()).encode();
                 TaskEdge {
                     cursor,
-                    node: Task { task: t },
+                    node: Task {
+                        prefetched_cache_operations: cache_operations_by_task_id.remove(&t.id.0),
+                        task: t,
+                    },
                 }
             })
             .collect();
@@ -234,6 +247,7 @@ impl BuildScan {
 // ---------------------------------------------------------------------------
 
 pub struct Task {
+    pub prefetched_cache_operations: Option<Vec<domain::CacheOperation>>,
     pub task: domain::Task,
 }
 
@@ -315,6 +329,14 @@ impl Task {
     }
 
     async fn cache_operations(&self, context: &Context) -> FieldResult<Vec<CacheOperation>> {
+        if let Some(prefetched_cache_operations) = &self.prefetched_cache_operations {
+            return Ok(prefetched_cache_operations
+                .iter()
+                .cloned()
+                .map(|op| CacheOperation { op })
+                .collect());
+        }
+
         let task_id = self.task.id.0.to_string();
         let ops = context
             .service
@@ -641,7 +663,12 @@ impl QueryRoot {
                     .get_task(&relay_id.raw_id)
                     .await
                     .map_err(|e| FieldError::from(e.to_string()))?;
-                Ok(task.map(|t| NodeValue::Task(Task { task: t })))
+                Ok(task.map(|t| {
+                    NodeValue::Task(Task {
+                        prefetched_cache_operations: None,
+                        task: t,
+                    })
+                }))
             }
             "Test" => {
                 let test = context

--- a/build-scan/server/service/src/lib.rs
+++ b/build-scan/server/service/src/lib.rs
@@ -315,8 +315,9 @@ impl BuildScanService {
         };
 
         let scan_id = task.scan_id.0.to_string();
+        let task_ids = vec![task.id.0.to_string()];
         let dependencies_by_task_id =
-            db::list_task_dependency_map_for_scan(&self.pool, &scan_id).await?;
+            db::list_task_dependency_map_for_tasks(&self.pool, &scan_id, &task_ids).await?;
 
         Ok(Some(Self::hydrate_task_dependencies(
             task,
@@ -331,8 +332,12 @@ impl BuildScanService {
         after_id: Option<&str>,
     ) -> Result<Vec<domain::Task>> {
         let tasks = db::list_tasks(&self.pool, scan_id, limit, after_id).await?;
+        let task_ids = tasks
+            .iter()
+            .map(|task| task.id.0.to_string())
+            .collect::<Vec<_>>();
         let dependencies_by_task_id =
-            db::list_task_dependency_map_for_scan(&self.pool, scan_id).await?;
+            db::list_task_dependency_map_for_tasks(&self.pool, scan_id, &task_ids).await?;
 
         Ok(tasks
             .into_iter()
@@ -448,5 +453,12 @@ impl BuildScanService {
         task_id: &str,
     ) -> Result<Vec<domain::CacheOperation>> {
         db::list_cache_operations(&self.pool, task_id).await
+    }
+
+    pub async fn list_cache_operations_for_tasks(
+        &self,
+        task_ids: &[String],
+    ) -> Result<BTreeMap<Uuid, Vec<domain::CacheOperation>>> {
+        db::list_cache_operations_for_tasks(&self.pool, task_ids).await
     }
 }

--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -1,0 +1,78 @@
+val syntheticTaskCount = providers
+    .gradleProperty("syntheticTaskCount")
+    .orNull
+    ?.toIntOrNull()
+    ?: 0
+
+val syntheticTaskLayerWidth = providers
+    .gradleProperty("syntheticTaskLayerWidth")
+    .orNull
+    ?.toIntOrNull()
+    ?: 40
+
+val syntheticTaskFanIn = providers
+    .gradleProperty("syntheticTaskFanIn")
+    .orNull
+    ?.toIntOrNull()
+    ?: 3
+
+if (syntheticTaskCount > 0) {
+    val taskCount = syntheticTaskCount.coerceAtMost(10_000)
+    val layerWidth = syntheticTaskLayerWidth.coerceAtLeast(1)
+    val fanIn = syntheticTaskFanIn.coerceAtLeast(1)
+
+    fun taskName(index: Int): String = "syntheticTask${index.toString().padStart(4, '0')}"
+
+    fun dependencyIndexes(index: Int): List<Int> {
+        val layer = index / layerWidth
+        if (layer == 0) {
+            return emptyList()
+        }
+
+        val previousLayerStart = (layer - 1) * layerWidth
+        val previousLayerEndExclusive = minOf(layer * layerWidth, taskCount)
+        val previousLayerSize = previousLayerEndExclusive - previousLayerStart
+        val dependencyCount = minOf(fanIn, previousLayerSize)
+
+        return (0 until dependencyCount)
+            .map { offset ->
+                previousLayerStart + ((index + (offset * 7)) % previousLayerSize)
+            }
+            .distinct()
+    }
+
+    val syntheticTasks = (0 until taskCount).associateWith { index ->
+        tasks.register(taskName(index)) {
+            group = "verification"
+            description = "Synthetic task ${index + 1} of $taskCount for build scan performance testing"
+            outputs.upToDateWhen { false }
+            doLast {
+                // Intentionally empty: we only need a deterministic execution graph.
+            }
+        }
+    }
+
+    syntheticTasks.forEach { (index, taskProvider) ->
+        taskProvider.configure {
+            dependencyIndexes(index).forEach { dependencyIndex ->
+                dependsOn(syntheticTasks.getValue(dependencyIndex))
+            }
+        }
+    }
+
+    tasks.register("syntheticTaskGraph") {
+        group = "verification"
+        description = "Executes a deterministic synthetic DAG for build scan performance testing"
+
+        val finalLayerStart = ((taskCount - 1) / layerWidth) * layerWidth
+        dependsOn(
+            (finalLayerStart until taskCount).map { index -> syntheticTasks.getValue(index) },
+        )
+
+        doLast {
+            println(
+                "Executed synthetic task graph with $taskCount tasks, layer width $layerWidth, and fan-in $fanIn.",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a synthetic Gradle task graph generator so large task/dependency scans can be reproduced locally
- batch paginated task metadata on the server and scope dependency hydration to the current page instead of the whole scan
- defer heavy Tasks-tab rendering and hide very large dependency graphs by default to avoid browser stalls

## Verification
- bazel run gazelle
- bazel run //tools/format
- aspect lint //...
- aspect test //angular/projects/build-scan-web:test
- aspect test //...
- aspect build //...
- browser verification with agent-browser against a synthetic 2,417-task scan

## Results
- GraphQL pagination time improved from about 1.15s to 0.50s on the synthetic large scan
- Tasks tab render time improved from about 26-27s to about 1.5s on the same scan