### PR TITLE
Show critical path for large task graphs

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.spec.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { TestBed, type ComponentFixture } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import {
   ApolloTestingModule,
   ApolloTestingController,
 } from "apollo-angular/testing";
 import { ScanTasksTabComponent } from "./scan-tasks-tab.component";
+import { TaskDependencyGraphComponent } from "./task-dependency-graph/task-dependency-graph.component";
 
 function buildTaskEdge(overrides: Record<string, unknown> = {}) {
   return {
@@ -163,23 +165,57 @@ describe("ScanTasksTabComponent", () => {
     expect(fixture.nativeElement.querySelector("app-tasks-table")).toBeTruthy();
   });
 
-  it("hides the dependency graph by default for very large scans", () => {
+  it("renders only the critical path by default for very large scans", () => {
     const largeFixture = createFixture(1000);
 
     const pending = controller.expectOne("GetScanTasks");
     pending.flushData({
-      buildScan: buildTaskScan([buildTaskEdge()], {
-        hasNextPage: false,
-        endCursor: null,
-      }),
+      buildScan: buildTaskScan(
+        [
+          buildTaskEdge({
+            id: "ROOT",
+            taskPath: ":root",
+            durationMs: 10,
+          }),
+          buildTaskEdge({
+            id: "FAST",
+            dependencies: ["ROOT"],
+            taskPath: ":fast",
+            durationMs: 20,
+          }),
+          buildTaskEdge({
+            id: "SLOW",
+            dependencies: ["ROOT"],
+            taskPath: ":slow",
+            durationMs: 80,
+          }),
+          buildTaskEdge({
+            id: "END",
+            dependencies: ["SLOW"],
+            taskPath: ":end",
+            durationMs: 30,
+          }),
+        ],
+        { hasNextPage: false, endCursor: null },
+      ),
     });
     largeFixture.detectChanges();
 
-    expect(
-      largeFixture.nativeElement.querySelector("app-task-dependency-graph"),
-    ).toBeNull();
+    const graphDebugElement = largeFixture.debugElement.query(
+      By.directive(TaskDependencyGraphComponent),
+    );
+
+    expect(graphDebugElement).toBeTruthy();
+    const graphComponent =
+      graphDebugElement.componentInstance as TaskDependencyGraphComponent;
+    expect(graphComponent.taskEdges().map((edge) => edge.node.id)).toEqual([
+      "ROOT",
+      "SLOW",
+      "END",
+    ]);
+    expect(largeFixture.nativeElement.textContent).toContain("Critical Path");
     expect(largeFixture.nativeElement.textContent).toContain(
-      "Task dependency graph hidden",
+      "Showing the longest weighted dependency chain",
     );
 
     const buttons = Array.from(
@@ -187,16 +223,54 @@ describe("ScanTasksTabComponent", () => {
     ) as HTMLButtonElement[];
 
     const button = buttons.find((candidate) =>
-      candidate.textContent?.includes("Render graph anyway"),
+      candidate.textContent?.includes("Render full graph anyway"),
     );
 
-    expect(button).toBeTruthy();
-    button?.click();
+    expect(button).toBeUndefined();
+
+    largeFixture.destroy();
+  });
+
+  it("uses origin execution time when duration is unavailable for critical path selection", () => {
+    const largeFixture = createFixture(1000);
+
+    const pending = controller.expectOne("GetScanTasks");
+    pending.flushData({
+      buildScan: buildTaskScan(
+        [
+          buildTaskEdge({
+            id: "ROOT",
+            taskPath: ":root",
+            durationMs: 10,
+          }),
+          buildTaskEdge({
+            id: "DURATION_PATH",
+            dependencies: ["ROOT"],
+            taskPath: ":durationPath",
+            durationMs: 20,
+            originExecutionTime: 20,
+          }),
+          buildTaskEdge({
+            id: "ORIGIN_PATH",
+            dependencies: ["ROOT"],
+            taskPath: ":originPath",
+            durationMs: null,
+            originExecutionTime: 90,
+          }),
+        ],
+        { hasNextPage: false, endCursor: null },
+      ),
+    });
     largeFixture.detectChanges();
 
-    expect(
-      largeFixture.nativeElement.querySelector("app-task-dependency-graph"),
-    ).toBeTruthy();
+    const graphComponent = largeFixture.debugElement.query(
+      By.directive(TaskDependencyGraphComponent),
+    ).componentInstance as TaskDependencyGraphComponent;
+
+    expect(graphComponent.taskEdges().map((edge) => edge.node.id)).toEqual([
+      "ROOT",
+      "ORIGIN_PATH",
+    ]);
 
     largeFixture.destroy();
   });

--- a/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.ts
@@ -75,6 +75,156 @@ interface PartialTaskScan {
 
 const LARGE_GRAPH_TASK_THRESHOLD = 500;
 
+function taskWeight(edge: TaskEdge): number {
+  return Math.max(
+    0,
+    edge.node.durationMs ?? edge.node.originExecutionTime ?? 0,
+  );
+}
+
+function compareCriticalPathCandidates(
+  left: { score: number; length: number; edge: TaskEdge },
+  right: { score: number; length: number; edge: TaskEdge },
+): number {
+  const scoreDelta = left.score - right.score;
+  if (scoreDelta !== 0) return scoreDelta;
+
+  const lengthDelta = left.length - right.length;
+  if (lengthDelta !== 0) return lengthDelta;
+
+  const pathDelta = right.edge.node.taskPath.localeCompare(
+    left.edge.node.taskPath,
+  );
+  return pathDelta !== 0
+    ? pathDelta
+    : right.edge.node.id.localeCompare(left.edge.node.id);
+}
+
+function selectCriticalPathTaskEdges(taskEdges: TaskEdge[]): TaskEdge[] {
+  if (taskEdges.length <= 1) return taskEdges;
+
+  const edgeById = new Map(taskEdges.map((edge) => [edge.node.id, edge]));
+  const successorsById = new Map<string, string[]>();
+  const predecessorsById = new Map<string, string[]>();
+  const indegreeById = new Map<string, number>();
+
+  for (const edge of taskEdges) {
+    successorsById.set(edge.node.id, []);
+    predecessorsById.set(edge.node.id, []);
+    indegreeById.set(edge.node.id, 0);
+  }
+
+  for (const edge of taskEdges) {
+    for (const dependencyId of edge.node.dependencies ?? []) {
+      if (!edgeById.has(dependencyId) || dependencyId === edge.node.id)
+        continue;
+      successorsById.get(dependencyId)?.push(edge.node.id);
+      predecessorsById.get(edge.node.id)?.push(dependencyId);
+      indegreeById.set(edge.node.id, (indegreeById.get(edge.node.id) ?? 0) + 1);
+    }
+  }
+
+  const ready = taskEdges
+    .filter((edge) => (indegreeById.get(edge.node.id) ?? 0) === 0)
+    .sort((left, right) =>
+      left.node.taskPath.localeCompare(right.node.taskPath),
+    );
+  const topoOrder: TaskEdge[] = [];
+
+  while (ready.length > 0) {
+    const edge = ready.shift();
+    if (!edge) continue;
+    topoOrder.push(edge);
+
+    for (const successorId of successorsById.get(edge.node.id) ?? []) {
+      const nextIndegree = (indegreeById.get(successorId) ?? 0) - 1;
+      indegreeById.set(successorId, nextIndegree);
+      if (nextIndegree === 0) {
+        const successor = edgeById.get(successorId);
+        if (successor) {
+          ready.push(successor);
+          ready.sort((left, right) =>
+            left.node.taskPath.localeCompare(right.node.taskPath),
+          );
+        }
+      }
+    }
+  }
+
+  if (topoOrder.length !== taskEdges.length) {
+    const topWeightedEdge = [...taskEdges].sort((left, right) => {
+      const weightDelta = taskWeight(right) - taskWeight(left);
+      return weightDelta !== 0
+        ? weightDelta
+        : left.node.taskPath.localeCompare(right.node.taskPath);
+    })[0];
+    return topWeightedEdge ? [topWeightedEdge] : [];
+  }
+
+  const bestScoreById = new Map<string, number>();
+  const bestLengthById = new Map<string, number>();
+  const previousIdById = new Map<string, string | null>();
+
+  for (const edge of topoOrder) {
+    let previousId: string | null = null;
+    let previousScore = 0;
+    let previousLength = 0;
+
+    for (const predecessorId of predecessorsById.get(edge.node.id) ?? []) {
+      const predecessor = edgeById.get(predecessorId);
+      if (!predecessor) continue;
+      const candidate = {
+        score: bestScoreById.get(predecessorId) ?? 0,
+        length: bestLengthById.get(predecessorId) ?? 0,
+        edge: predecessor,
+      };
+      const current = {
+        score: previousScore,
+        length: previousLength,
+        edge: previousId
+          ? (edgeById.get(previousId) ?? predecessor)
+          : predecessor,
+      };
+      if (
+        !previousId ||
+        compareCriticalPathCandidates(candidate, current) > 0
+      ) {
+        previousId = predecessorId;
+        previousScore = candidate.score;
+        previousLength = candidate.length;
+      }
+    }
+
+    bestScoreById.set(edge.node.id, previousScore + taskWeight(edge));
+    bestLengthById.set(edge.node.id, previousLength + 1);
+    previousIdById.set(edge.node.id, previousId);
+  }
+
+  const terminalEdge = topoOrder.reduce<TaskEdge | null>((best, edge) => {
+    if (!best) return edge;
+    const candidate = {
+      score: bestScoreById.get(edge.node.id) ?? 0,
+      length: bestLengthById.get(edge.node.id) ?? 0,
+      edge,
+    };
+    const current = {
+      score: bestScoreById.get(best.node.id) ?? 0,
+      length: bestLengthById.get(best.node.id) ?? 0,
+      edge: best,
+    };
+    return compareCriticalPathCandidates(candidate, current) > 0 ? edge : best;
+  }, null);
+
+  const pathIds = new Set<string>();
+  let currentId = terminalEdge?.node.id ?? null;
+  while (currentId) {
+    pathIds.add(currentId);
+    currentId = previousIdById.get(currentId) ?? null;
+  }
+
+  return taskEdges.filter((edge) => pathIds.has(edge.node.id));
+}
+
 const GET_SCAN_TASKS = gql`
   query GetScanTasks($id: ID!, $firstTasks: Int!, $afterTasks: String) {
     buildScan(id: $id) {
@@ -146,24 +296,23 @@ const GET_SCAN_TASKS = gql`
         />
 
         @if (showDependencyGraph()) {
-          <app-task-dependency-graph [taskEdges]="taskEdges()" />
-        } @else if (hasLargeTaskGraph()) {
+          <app-task-dependency-graph
+            [taskEdges]="displayedGraphTaskEdges()"
+            [title]="dependencyGraphTitle()"
+            [description]="dependencyGraphDescription()"
+          />
+        }
+
+        @if (hasLargeTaskGraph()) {
           <div
             class="rounded-md border border-base-300 bg-base-200 p-4 text-sm"
           >
-            <div class="font-semibold">Task dependency graph hidden</div>
+            <div class="font-semibold">Showing critical path only</div>
             <p class="mt-1 opacity-70">
-              This scan has {{ taskCount() }} tasks. Rendering the full
-              dependency graph for very large scans can stall the browser, so
-              the graph is hidden by default.
+              This scan has {{ taskCount() }} tasks. The full dependency graph
+              can stall the browser, so the graph above shows the critical path
+              by default.
             </p>
-            <button
-              class="btn btn-sm mt-3"
-              type="button"
-              (click)="renderLargeGraph.set(true)"
-            >
-              Render graph anyway
-            </button>
           </div>
         }
 
@@ -188,12 +337,26 @@ export class ScanTasksTabComponent implements OnInit {
 
   taskEdges = signal<TaskEdge[]>([]);
   loading = signal(true);
-  renderLargeGraph = signal(false);
   hasLargeTaskGraph = computed(
     () => this.taskCount() > LARGE_GRAPH_TASK_THRESHOLD,
   );
   showDependencyGraph = computed(
-    () => !this.hasLargeTaskGraph() || this.renderLargeGraph(),
+    () => !this.loading() && this.taskEdges().length > 0,
+  );
+  displayedGraphTaskEdges = computed(() =>
+    this.hasLargeTaskGraph()
+      ? selectCriticalPathTaskEdges(this.taskEdges())
+      : this.taskEdges(),
+  );
+  dependencyGraphTitle = computed(() =>
+    this.hasLargeTaskGraph()
+      ? "Critical Path"
+      : "Task Dependencies",
+  );
+  dependencyGraphDescription = computed(() =>
+    this.hasLargeTaskGraph()
+      ? "Showing the longest weighted dependency chain."
+      : "Static graph of task prerequisites.",
   );
 
   private loadRemainingPages(
@@ -228,7 +391,6 @@ export class ScanTasksTabComponent implements OnInit {
       .pipe(
         switchMap((id) => {
           this.taskEdges.set([]);
-          this.renderLargeGraph.set(false);
           if (this.taskCount() === 0) {
             this.loading.set(false);
             return EMPTY;

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
@@ -34,6 +34,21 @@ describe("TaskDependencyGraphComponent", () => {
     fixture.detectChanges();
   }
 
+  it("renders custom title and description copy", () => {
+    fixture.componentRef.setInput("taskEdges", [buildTaskEdge()]);
+    fixture.componentRef.setInput("title", "Critical Path");
+    fixture.componentRef.setInput(
+      "description",
+      "Showing the longest weighted dependency chain.",
+    );
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain("Critical Path");
+    expect(fixture.nativeElement.textContent).toContain(
+      "Showing the longest weighted dependency chain.",
+    );
+  });
+
   describe("graph layout", () => {
     it("builds labeled nodes and directed edges from per-task dependencies", () => {
       render([
@@ -84,6 +99,29 @@ describe("TaskDependencyGraphComponent", () => {
         expect.objectContaining({ id: "T2", label: ":processResources" }),
       ]);
       expect(graph.edges).toEqual([]);
+    });
+
+    it("drops cyclic dependency edges before rendering the graph layout", () => {
+      render([
+        buildTaskEdge({
+          id: "T1",
+          dependencies: ["T2"],
+          taskPath: ":compileJava",
+        }),
+        buildTaskEdge({
+          id: "T2",
+          dependencies: ["T1"],
+          taskPath: ":processResources",
+        }),
+      ]);
+
+      const graph = component.graph();
+      expect(graph.nodes.map((node) => node.id)).toEqual(["T1", "T2"]);
+      expect(graph.edges).toEqual([]);
+      expect(component.layout().nodes.map((node) => node.id)).toEqual([
+        "T1",
+        "T2",
+      ]);
     });
 
     it("orders nodes within a Sugiyama layer to reduce dependency crossings", () => {

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
@@ -264,6 +264,45 @@ function edgeKey(edge: TaskDependencyEdge): string {
   return `${edge.sourceId}:${edge.targetId}`;
 }
 
+function hasPath(
+  sourceId: string,
+  targetId: string,
+  edges: readonly TaskDependencyEdge[],
+  ignoredEdge: TaskDependencyEdge,
+): boolean {
+  const successorsById = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (
+      edge.sourceId === ignoredEdge.sourceId &&
+      edge.targetId === ignoredEdge.targetId
+    ) {
+      continue;
+    }
+    const successors = successorsById.get(edge.sourceId) ?? [];
+    successors.push(edge.targetId);
+    successorsById.set(edge.sourceId, successors);
+  }
+
+  const visited = new Set<string>();
+  const pending = [sourceId];
+  while (pending.length > 0) {
+    const currentId = pending.pop();
+    if (!currentId || visited.has(currentId)) continue;
+    if (currentId === targetId) return true;
+    visited.add(currentId);
+    pending.push(...(successorsById.get(currentId) ?? []));
+  }
+  return false;
+}
+
+function dropCyclicEdges(
+  edges: readonly TaskDependencyEdge[],
+): TaskDependencyEdge[] {
+  return edges.filter(
+    (edge) => !hasPath(edge.targetId, edge.sourceId, edges, edge),
+  );
+}
+
 @Component({
   selector: "app-task-dependency-graph",
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -272,9 +311,9 @@ function edgeKey(edge: TaskDependencyEdge): string {
       <div class="card-body p-4">
         <div class="mb-3 flex items-start justify-between gap-4">
           <div>
-            <h4 class="font-semibold">Task Dependencies</h4>
+            <h4 class="font-semibold">{{ title() }}</h4>
             <p class="text-xs opacity-60">
-              Static graph of task prerequisites.
+              {{ description() }}
             </p>
           </div>
           @if (layout().nodes.length > 0) {
@@ -408,6 +447,8 @@ function edgeKey(edge: TaskDependencyEdge): string {
 })
 export class TaskDependencyGraphComponent {
   taskEdges = input.required<TaskEdge[]>();
+  title = input("Task Dependencies");
+  description = input("Static graph of task prerequisites.");
   legendNodeItems = LEGEND_NODE_ITEMS;
   readonly edgeKey = edgeKey;
 
@@ -462,27 +503,29 @@ export class TaskDependencyGraphComponent {
 
     const nodeIds = new Set(nodes.map((node) => node.id));
     const seenEdges = new Set<string>();
-    const edges = [...tasks.values()]
-      .flatMap((task) =>
-        (task.dependencies ?? []).map((sourceId) => ({
-          sourceId,
-          targetId: task.id,
-        })),
-      )
-      .filter(
-        (edge): edge is TaskDependencyEdge =>
-          !!edge.sourceId &&
-          !!edge.targetId &&
-          nodeIds.has(edge.sourceId) &&
-          nodeIds.has(edge.targetId) &&
-          edge.sourceId !== edge.targetId,
-      )
-      .filter((edge) => {
-        const key = `${edge.sourceId}:${edge.targetId}`;
-        if (seenEdges.has(key)) return false;
-        seenEdges.add(key);
-        return true;
-      });
+    const edges = dropCyclicEdges(
+      [...tasks.values()]
+        .flatMap((task) =>
+          (task.dependencies ?? []).map((sourceId) => ({
+            sourceId,
+            targetId: task.id,
+          })),
+        )
+        .filter(
+          (edge): edge is TaskDependencyEdge =>
+            !!edge.sourceId &&
+            !!edge.targetId &&
+            nodeIds.has(edge.sourceId) &&
+            nodeIds.has(edge.targetId) &&
+            edge.sourceId !== edge.targetId,
+        )
+        .filter((edge) => {
+          const key = `${edge.sourceId}:${edge.targetId}`;
+          if (seenEdges.has(key)) return false;
+          seenEdges.add(key);
+          return true;
+        }),
+    );
 
     return { nodes, edges };
   });


### PR DESCRIPTION
## Summary
- Render a critical-path dependency graph by default for large task scans instead of exposing the full graph.
- Add custom graph copy so the reduced graph is labeled as `Critical Path`.
- Drop cyclic dependency edges before d3-dag layout to avoid graph crashes.

## Verification
- `aspect lint //angular/projects/build-scan-web`
- `aspect test //angular/projects/build-scan-web:test`
- `aspect build //angular/projects/build-scan-web`
- Agent-browser QA on a seeded 600-task scan confirmed `Critical Path`, `6 nodes · 5 edges`, no `Render full graph anyway` button, and screenshot `/tmp/critical-path-no-full-graph.png`.