### PR TITLE
feat: Add minimap to task graph

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
@@ -35,6 +35,7 @@ const g6Mock = vi.hoisted(() => {
     node?: Record<string, unknown>;
     edge?: Record<string, unknown>;
     behaviors?: string[];
+    plugins?: Array<Record<string, unknown>>;
   };
   type HoistedElementStateMap = Record<string, string[]>;
 
@@ -413,6 +414,14 @@ describe("TaskDependencyGraphComponent", () => {
       expect(instance.options.behaviors).toEqual([
         "drag-canvas",
         "zoom-canvas",
+      ]);
+      expect(instance.options.plugins).toEqual([
+        {
+          type: "minimap",
+          key: "task-graph-minimap",
+          size: [240, 160],
+          position: "right-bottom",
+        },
       ]);
       expect(instance.data.nodes).toEqual(
         expect.arrayContaining([

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
@@ -522,6 +522,14 @@ export class TaskDependencyGraphComponent {
       zoomRange: [0.5, 2.5],
       animation: false,
       behaviors: ["drag-canvas", "zoom-canvas"],
+      plugins: [
+        {
+          type: "minimap",
+          key: "task-graph-minimap",
+          size: [240, 160],
+          position: "right-bottom",
+        },
+      ],
       node: {
         type: "circle",
         state: {


### PR DESCRIPTION
## Summary
- Add the built-in G6 minimap plugin to the task dependency graph.
- Cover the minimap configuration in the existing task graph component test while preserving drag/zoom behavior assertions.

## Testing
- `bazel run gazelle`
- `bazel run //tools/format`
- `aspect test //angular/projects/build-scan-web:test`
- `aspect lint //...`
- `aspect test //...`
- `aspect build //...`
- Browser QA via local scan: verified visible 240x160 minimap and preserved drag/zoom interaction.