### PR TITLE
feat: select critical path target task

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-detail.component.ts
@@ -70,6 +70,7 @@ const GET_BUILD_SCAN_OVERVIEW = gql`
               <app-scan-tasks-tab
                 [scanId]="scan.id"
                 [taskCount]="scan.taskCount"
+                [requestedTasks]="scan.requestedTasks ?? []"
               />
             </section>
           }

--- a/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.ts
@@ -146,7 +146,10 @@ const GET_SCAN_TASKS = gql`
         />
 
         @if (showDependencyGraph()) {
-          <app-task-dependency-graph [taskEdges]="taskEdges()" />
+          <app-task-dependency-graph
+            [taskEdges]="taskEdges()"
+            [requestedTasks]="requestedTasks()"
+          />
         } @else if (hasLargeTaskGraph()) {
           <div
             class="rounded-md border border-base-300 bg-base-200 p-4 text-sm"
@@ -181,6 +184,7 @@ const GET_SCAN_TASKS = gql`
 export class ScanTasksTabComponent implements OnInit {
   scanId = input.required<string>();
   taskCount = input.required<number>();
+  readonly requestedTasks = input<readonly string[]>([]);
 
   private apollo = inject(Apollo);
   private destroyRef = inject(DestroyRef);

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
@@ -361,9 +361,173 @@ describe("TaskDependencyGraphComponent", () => {
   });
 
   describe("critical path state", () => {
+    it("derives terminal task options from sink nodes only", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build" }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":compileJava",
+        }),
+        buildTaskEdge({ id: "C", dependencies: ["B"], taskPath: ":test" }),
+      ]);
+
+      expect(component.graph().nodes.map((node) => node.id)).toEqual([
+        "A",
+        "B",
+        "C",
+      ]);
+      expect(component.graph().edges).toEqual([
+        { sourceId: "A", targetId: "B" },
+        { sourceId: "B", targetId: "C" },
+      ]);
+      expect(component.terminalOptions().map((option) => option.label)).toEqual(
+        [":test"],
+      );
+    });
+
+    it("treats the selected terminal target as the critical-path anchor and keeps invalid typed values unhighlighted", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":compileJava", durationMs: 10 }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":test",
+          durationMs: 20,
+        }),
+      ]);
+
+      component.selectCriticalPathTarget(":test");
+      component.showCriticalPath.set(true);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.targetInputValue()).toBe(":test");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
+      expect(component.criticalPathWarning()).toBeNull();
+      expect(component.highlightState()?.mode).toBe("critical");
+      expect(highlightedNodeIds()).toEqual(["A", "B"]);
+      expect(highlightedEdgeKeys()).toEqual(["A:B"]);
+
+      component.selectCriticalPathTarget(":missing");
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.targetInputValue()).toBe(":missing");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+      expect(component.highlightState()).toBeNull();
+      expect(component.criticalPathWarning()).toContain("terminal task");
+    });
+
+    it("handles zero, multiple, missing, non-terminal, and terminal requested-task preselection cases", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build" }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":compileJava",
+        }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", []);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+
+      fixture.componentRef.setInput("requestedTasks", [":build", ":test"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+
+      fixture.componentRef.setInput("requestedTasks", [":missing"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+
+      fixture.componentRef.setInput("requestedTasks", [":build"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+      expect(component.targetInputValue()).toBe("");
+
+      fixture.componentRef.setInput("requestedTasks", [":compileJava"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.terminalOptions().map((option) => option.label)).toEqual(
+        [":compileJava"],
+      );
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
+      expect(component.targetInputValue()).toBe(":compileJava");
+    });
+
+    it("preselects a terminal requested task and keeps a user-modified target across requestedTasks changes", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build" }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":compileJava",
+        }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", [":compileJava"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
+
+      component.selectCriticalPathTarget(":compileJava");
+      expect(component.targetInputValue()).toBe(":compileJava");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
+
+      fixture.componentRef.setInput("requestedTasks", [":missing"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
+    });
+
+    it("reconciles stale targets on graph changes without overriding user-modified targets", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":compileJava" }),
+        buildTaskEdge({ id: "B", dependencies: ["A"], taskPath: ":test" }),
+      ]);
+
+      component.selectCriticalPathTarget(":test");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
+
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":compileJava" }),
+        buildTaskEdge({ id: "C", dependencies: ["A"], taskPath: ":check" }),
+      ]);
+
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+
+      component.selectCriticalPathTarget(":check");
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":compileJava" }),
+        buildTaskEdge({ id: "C", dependencies: ["A"], taskPath: ":check" }),
+        buildTaskEdge({ id: "D", dependencies: ["C"], taskPath: ":assemble" }),
+      ]);
+
+      expect(component.targetInputValue()).toBe(":check");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+    });
+
     it("computes a critical path through dependency edge direction", async () => {
       await render([
-        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 10 }),
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 80 }),
         buildTaskEdge({
           id: "B",
           dependencies: ["A"],
@@ -378,6 +542,11 @@ describe("TaskDependencyGraphComponent", () => {
         }),
       ]);
 
+      fixture.componentRef.setInput("requestedTasks", [":c"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
       component.showCriticalPath.set(true);
 
       expect(component.highlightState()?.mode).toBe("critical");
@@ -386,16 +555,16 @@ describe("TaskDependencyGraphComponent", () => {
       expect(component.criticalPathHasCycle()).toBe(false);
     });
 
-    it("chooses the global longest cumulative path in disconnected graphs", async () => {
+    it("highlights only the requested terminal path in disconnected graphs", async () => {
       await render([
-        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 100 }),
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 80 }),
         buildTaskEdge({
           id: "B",
           dependencies: ["A"],
           taskPath: ":b",
           durationMs: 1,
         }),
-        buildTaskEdge({ id: "C", taskPath: ":c", durationMs: 10 }),
+        buildTaskEdge({ id: "C", taskPath: ":c", durationMs: 80 }),
         buildTaskEdge({
           id: "D",
           dependencies: ["C"],
@@ -410,41 +579,75 @@ describe("TaskDependencyGraphComponent", () => {
         }),
       ]);
 
+      fixture.componentRef.setInput("requestedTasks", [":b"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
       component.showCriticalPath.set(true);
 
       expect(highlightedNodeIds()).toEqual(["A", "B"]);
       expect(highlightedEdgeKeys()).toEqual(["A:B"]);
     });
 
-    it("breaks equal-score ties with the lexicographically smallest full node-id path", async () => {
+    it("breaks equal-score ties by the lexicographically smallest terminal path", async () => {
       await render([
-        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 5 }),
-        buildTaskEdge({ id: "B", taskPath: ":b", durationMs: 5 }),
+        buildTaskEdge({ id: "A", taskPath: ":alpha", durationMs: 4 }),
+        buildTaskEdge({ id: "B", taskPath: ":beta", durationMs: 4 }),
+        buildTaskEdge({ id: "C", taskPath: ":gamma", durationMs: 8 }),
         buildTaskEdge({
-          id: "C",
-          dependencies: ["A", "B"],
-          taskPath: ":c",
-          durationMs: 5,
+          id: "D",
+          dependencies: ["A"],
+          taskPath: ":delta",
+          durationMs: 6,
+        }),
+        buildTaskEdge({
+          id: "E",
+          dependencies: ["B"],
+          taskPath: ":epsilon",
+          durationMs: 6,
+        }),
+        buildTaskEdge({
+          id: "F",
+          dependencies: ["C", "D", "E"],
+          taskPath: ":zeta",
+          durationMs: 2,
         }),
       ]);
 
+      fixture.componentRef.setInput("requestedTasks", [":zeta"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
       component.showCriticalPath.set(true);
 
-      expect(highlightedNodeIds()).toEqual(["A", "C"]);
-      expect(highlightedEdgeKeys()).toEqual(["A:C"]);
+      expect(highlightedNodeIds()).toEqual(["A", "D", "F"]);
+      expect(highlightedEdgeKeys()).toEqual(["A:D", "D:F"]);
     });
 
-    it("treats null durations as zero", async () => {
+    it("treats null durations as zero in terminal critical-path scoring", async () => {
       await render([
-        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: null }),
+        buildTaskEdge({ id: "A", taskPath: ":alpha", durationMs: null }),
         buildTaskEdge({
           id: "B",
           dependencies: ["A"],
-          taskPath: ":b",
-          durationMs: 10,
+          taskPath: ":beta",
+          durationMs: 5,
         }),
-        buildTaskEdge({ id: "C", taskPath: ":c", durationMs: 9 }),
+        buildTaskEdge({ id: "C", taskPath: ":gamma", durationMs: 4 }),
+        buildTaskEdge({
+          id: "D",
+          dependencies: ["C"],
+          taskPath: ":delta",
+          durationMs: 3,
+        }),
       ]);
+
+      fixture.componentRef.setInput("requestedTasks", [":beta"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
 
       component.showCriticalPath.set(true);
 
@@ -452,12 +655,16 @@ describe("TaskDependencyGraphComponent", () => {
       expect(highlightedEdgeKeys()).toEqual(["A:B"]);
     });
 
-    it("chooses the highest-duration isolated node and ties by node id", async () => {
+    it("resolves a single exact taskPath match without normalization", async () => {
       await render([
-        buildTaskEdge({ id: "B", taskPath: ":b", durationMs: 20 }),
-        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 20 }),
-        buildTaskEdge({ id: "C", taskPath: ":c", durationMs: 10 }),
+        buildTaskEdge({ id: "A", taskPath: ":app:build", durationMs: 10 }),
+        buildTaskEdge({ id: "B", taskPath: ":build", durationMs: 9 }),
       ]);
+
+      fixture.componentRef.setInput("requestedTasks", [":app:build"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
 
       component.showCriticalPath.set(true);
 
@@ -465,49 +672,111 @@ describe("TaskDependencyGraphComponent", () => {
       expect(highlightedEdgeKeys()).toEqual([]);
     });
 
-    it("returns no critical highlight and exposes a warning for cyclic graph data", async () => {
+    it("normalizes a root task request to a single matching node", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 11 }),
+        buildTaskEdge({ id: "B", taskPath: ":test", durationMs: 2 }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", ["build"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      component.showCriticalPath.set(true);
+
+      expect(highlightedNodeIds()).toEqual(["A"]);
+      expect(highlightedEdgeKeys()).toEqual([]);
+    });
+
+    it("returns no critical highlight when multiple tasks are requested", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 11 }),
+        buildTaskEdge({ id: "B", taskPath: ":test", durationMs: 2 }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", ["build", "test"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.criticalPathWarning()).toBeNull();
+      component.showCriticalPath.set(true);
+
+      expect(component.highlightState()).toBeNull();
+      expect(component.criticalPathHasCycle()).toBe(false);
+      expect(component.criticalPathWarning()).toContain(
+        "choose a terminal task from the selector",
+      );
+    });
+
+    it("returns no critical highlight when terminal resolution is missing or ambiguous", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 11 }),
+        buildTaskEdge({ id: "B", taskPath: ":build", durationMs: 2 }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", ["test"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.criticalPathWarning()).toBeNull();
+      component.showCriticalPath.set(true);
+
+      expect(component.highlightState()).toBeNull();
+      expect(highlightedNodeIds()).toEqual([]);
+      expect(highlightedEdgeKeys()).toEqual([]);
+      expect(component.criticalPathWarning()).toContain(
+        "choose a terminal task from the selector",
+      );
+
+      fixture.componentRef.setInput("requestedTasks", ["build"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.criticalPathWarning()).toContain(
+        "choose a terminal task from the selector",
+      );
+    });
+
+    it("renders the cycle warning and hides terminal text when both are possible", async () => {
       await render([
         buildTaskEdge({
           id: "A",
           dependencies: ["B"],
-          taskPath: ":a",
+          taskPath: ":build",
           durationMs: 10,
         }),
         buildTaskEdge({
           id: "B",
           dependencies: ["A"],
-          taskPath: ":b",
+          taskPath: ":build",
           durationMs: 20,
         }),
       ]);
 
-      component.showCriticalPath.set(true);
-
-      expect(component.highlightState()).toBeNull();
-      expect(component.criticalPathHasCycle()).toBe(true);
-    });
-
-    it("keeps selected-node state intact while critical-path mode is toggled", async () => {
-      await render([
-        buildTaskEdge({ id: "T1", taskPath: ":alpha", durationMs: 10 }),
-        buildTaskEdge({
-          id: "T2",
-          dependencies: ["T1"],
-          taskPath: ":beta",
-          durationMs: 20,
-        }),
-      ]);
-
-      component.selectNode("T2");
-      expect(component.highlightState()?.mode).toBe("selected");
-      expect(component.highlightState()?.activeNodeId).toBe("T2");
+      fixture.componentRef.setInput("requestedTasks", ["build"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
 
       component.showCriticalPath.set(true);
-      expect(component.highlightState()?.mode).toBe("critical");
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
 
-      component.showCriticalPath.set(false);
-      expect(component.highlightState()?.mode).toBe("selected");
-      expect(component.highlightState()?.activeNodeId).toBe("T2");
+      const warning = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-warning"]',
+      ) as HTMLElement;
+      expect(warning).toBeTruthy();
+      expect(warning.textContent).toContain("dependency cycle");
+      expect(warning.textContent).not.toContain("requested task");
     });
   });
 
@@ -806,35 +1075,93 @@ describe("TaskDependencyGraphComponent", () => {
       ]);
       const instance = graphInstance();
 
-      instance.emitNode("node:click", "T5");
+      fixture.componentRef.setInput("requestedTasks", [":delta"]);
       fixture.detectChanges();
       await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("selected");
-      expect(elementState(instance, "T5")).toEqual(["highlighted", "selected"]);
+      fixture.detectChanges();
+
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
+      component.showCriticalPath.set(true);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()?.mode).toBe("critical");
+      expect(elementState(instance, "T4")).toEqual(["critical"]);
+      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
 
       component.toggleCriticalPath();
       fixture.detectChanges();
       await settleAsyncWork(fixture);
+      expect(component.highlightState()).toBeNull();
+      expect(component.targetInputValue()).toBe(":delta");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
+      expect(elementState(instance, "T5")).toEqual([]);
+
+      component.showCriticalPath.set(true);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
       expect(component.highlightState()?.mode).toBe("critical");
+
+      instance.emitNode("node:click", "T5");
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()?.mode).toBe("critical");
+      expect(component.targetInputValue()).toBe(":delta");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
+      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
+
+      instance.emitCanvasClick();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()?.mode).toBe("critical");
+      expect(component.targetInputValue()).toBe(":delta");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
+      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
+
+      component.toggleCriticalPath();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()).toBeNull();
+      expect(component.targetInputValue()).toBe(":delta");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
+      expect(elementState(instance, "T5")).toEqual([]);
+
+      component.showCriticalPath.set(true);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()?.mode).toBe("critical");
+
+      instance.emitNode("node:click", "T5");
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()?.mode).toBe("critical");
+      expect(component.targetInputValue()).toBe(":delta");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
+      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
+
+      component.toggleCriticalPath();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()).toBeNull();
       expect(instance.elementStates).toMatchObject({
-        T1: ["critical"],
-        T2: ["critical"],
-        T4: ["critical"],
-        T3: ["dimmed"],
-        T5: ["dimmed"],
-        "T1:T2": ["critical"],
-        "T2:T4": ["critical"],
+        T1: [],
+        T2: [],
+        T4: [],
+        T3: [],
+        T5: [],
+        "T1:T2": [],
+        "T2:T4": [],
       } satisfies ElementStateMap);
       expect(elementState(instance, "T5")).not.toContain("selected");
 
       component.toggleCriticalPath();
       fixture.detectChanges();
       await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("selected");
-      expect(component.highlightState()?.activeNodeId).toBe("T5");
-      expect(elementState(instance, "T5")).toEqual(["highlighted", "selected"]);
-      expect(elementState(instance, "T1")).toEqual(["dimmed"]);
-      expect(elementState(instance, "T1:T2")).toEqual(["dimmed"]);
+      expect(component.highlightState()?.mode).toBe("critical");
+      expect(component.targetInputValue()).toBe(":delta");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
+      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
+      expect(elementState(instance, "T1")).toEqual(["critical"]);
+      expect(elementState(instance, "T1:T2")).toEqual(["critical"]);
     });
   });
 
@@ -899,6 +1226,109 @@ describe("TaskDependencyGraphComponent", () => {
       }
     });
 
+    it("renders a labeled native terminal target input wired to datalist options", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build" }),
+        buildTaskEdge({ id: "B", dependencies: ["A"], taskPath: ":test" }),
+        buildTaskEdge({ id: "C", dependencies: ["A"], taskPath: ":check" }),
+      ]);
+
+      const label = fixture.nativeElement.querySelector(
+        'label[for="task-critical-path-target-input"]',
+      ) as HTMLLabelElement;
+      const input = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-target-input"]',
+      ) as HTMLInputElement;
+      const datalist = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-target-options"]',
+      ) as HTMLDataListElement;
+      const help = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-target-help"]',
+      ) as HTMLElement;
+
+      expect(label).toBeTruthy();
+      expect(label.textContent?.trim()).toBe("Critical path target");
+      expect(label.htmlFor).toBe(input.id);
+      expect(input.getAttribute("list")).toBe(datalist.id);
+      expect(input.value).toBe(component.targetInputValue());
+      expect(input.disabled).toBe(false);
+      expect(help.textContent).toContain("Choose a terminal task");
+      expect(
+        Array.from(datalist.querySelectorAll("option")).map(
+          (option) => option.value,
+        ),
+      ).toEqual([":check", ":test"]);
+
+      input.value = ":test";
+      input.dispatchEvent(new Event("input"));
+      fixture.detectChanges();
+
+      expect(component.targetInputValue()).toBe(":test");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
+      expect(component.showCriticalPath()).toBe(false);
+    });
+
+    it("disables the terminal target input when no terminal tasks are available", async () => {
+      await render([
+        buildTaskEdge({ id: "A", dependencies: ["B"], taskPath: ":alpha" }),
+        buildTaskEdge({ id: "B", dependencies: ["A"], taskPath: ":beta" }),
+      ]);
+
+      const input = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-target-input"]',
+      ) as HTMLInputElement;
+      const datalist = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-target-options"]',
+      ) as HTMLDataListElement;
+      const help = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-target-help"]',
+      ) as HTMLElement;
+
+      expect(component.terminalOptions()).toEqual([]);
+      expect(input.disabled).toBe(true);
+      expect(input.getAttribute("list")).toBe(datalist.id);
+      expect(datalist.querySelectorAll("option")).toHaveLength(0);
+      expect(help.textContent).toContain("No terminal tasks are available");
+    });
+
+    it("shows invalid target helper text and avoids highlighting invalid values", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 10 }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":test",
+          durationMs: 20,
+        }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", [":test"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      const input = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-target-input"]',
+      ) as HTMLInputElement;
+      input.value = ":missing";
+      input.dispatchEvent(new Event("change"));
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      const help = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-target-help"]',
+      ) as HTMLElement;
+      expect(help.textContent).toContain("Value must match a terminal task");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+
+      component.toggleCriticalPath();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+
+      expect(component.highlightState()).toBeNull();
+    });
+
     it("renders an empty-state message without creating a G6 graph", async () => {
       await render([]);
 
@@ -930,21 +1360,16 @@ describe("TaskDependencyGraphComponent", () => {
       expect(g6Mock.MockGraph.instances).toHaveLength(0);
     });
 
-    it("renders the cycle warning only while critical path mode is enabled", async () => {
+    it("renders a terminal warning only after critical path mode is enabled", async () => {
       await render([
-        buildTaskEdge({
-          id: "A",
-          dependencies: ["B"],
-          taskPath: ":a",
-          durationMs: 10,
-        }),
-        buildTaskEdge({
-          id: "B",
-          dependencies: ["A"],
-          taskPath: ":b",
-          durationMs: 20,
-        }),
+        buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 10 }),
+        buildTaskEdge({ id: "B", taskPath: ":test", durationMs: 20 }),
       ]);
+
+      fixture.componentRef.setInput("requestedTasks", [":missing"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
 
       expect(
         fixture.nativeElement.querySelector(
@@ -964,17 +1389,72 @@ describe("TaskDependencyGraphComponent", () => {
         '[data-testid="task-critical-path-warning"]',
       ) as HTMLElement;
       expect(warning).toBeTruthy();
-      expect(warning.textContent).toContain("dependency cycle");
+      expect(warning.textContent).toContain(
+        "choose a terminal task from the selector",
+      );
+      expect(warning.textContent).not.toContain("dependency cycle");
+    });
 
-      toggle.click();
+    it("keeps cycle warnings ahead of target warnings", async () => {
+      await render([
+        buildTaskEdge({
+          id: "A",
+          dependencies: ["B"],
+          taskPath: ":build",
+          durationMs: 10,
+        }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":test",
+          durationMs: 20,
+        }),
+      ]);
+
+      component.selectCriticalPathTarget(":missing");
+      component.showCriticalPath.set(true);
       fixture.detectChanges();
       await settleAsyncWork(fixture);
       fixture.detectChanges();
+
+      expect(component.criticalPathHasCycle()).toBe(true);
+      expect(component.highlightState()).toBeNull();
+      expect(component.criticalPathWarning()).toContain("dependency cycle");
+      expect(component.criticalPathWarning()).not.toContain("terminal task");
+    });
+
+    it("renders a multiple-request warning after critical path mode is enabled", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 10 }),
+        buildTaskEdge({ id: "B", taskPath: ":test", durationMs: 20 }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", [":build", ":test"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
       expect(
         fixture.nativeElement.querySelector(
           '[data-testid="task-critical-path-warning"]',
         ),
       ).toBeFalsy();
+
+      const toggle = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-toggle"]',
+      ) as HTMLButtonElement;
+      toggle.click();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      const warning = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-warning"]',
+      ) as HTMLElement;
+      expect(warning).toBeTruthy();
+      expect(warning.textContent).toContain(
+        "choose a terminal task from the selector",
+      );
     });
   });
 });

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
@@ -574,6 +574,29 @@ describe("TaskDependencyGraphComponent", () => {
           endArrow: false,
         },
       });
+      expect(instance.options.node).toMatchObject({
+        state: {
+          highlighted: expect.objectContaining({ lineWidth: 3 }),
+          selected: expect.objectContaining({ lineWidth: 4 }),
+          critical: expect.objectContaining({
+            lineWidth: 5,
+            stroke: expect.any(String),
+            shadowBlur: 18,
+          }),
+          dimmed: expect.objectContaining({ opacity: 0.28 }),
+        },
+      });
+      expect(instance.options.edge).toMatchObject({
+        state: {
+          highlighted: expect.objectContaining({ lineWidth: 3 }),
+          critical: expect.objectContaining({
+            lineWidth: 5,
+            stroke: expect.any(String),
+            opacity: 1,
+          }),
+          dimmed: expect.objectContaining({ opacity: 0.12 }),
+        },
+      });
       expect(instance.options.behaviors).toEqual([
         "drag-canvas",
         "zoom-canvas",
@@ -762,6 +785,57 @@ describe("TaskDependencyGraphComponent", () => {
       expect(elementState(instance, "T4")).toEqual([]);
       expect(elementState(instance, "T6")).toEqual([]);
     });
+
+    it("pushes critical path states into G6 and restores selected states when disabled", async () => {
+      await render([
+        buildTaskEdge({ id: "T1", taskPath: ":alpha", durationMs: 10 }),
+        buildTaskEdge({
+          id: "T2",
+          dependencies: ["T1"],
+          taskPath: ":beta",
+          durationMs: 20,
+        }),
+        buildTaskEdge({ id: "T3", taskPath: ":gamma", durationMs: 1 }),
+        buildTaskEdge({
+          id: "T4",
+          dependencies: ["T2"],
+          taskPath: ":delta",
+          durationMs: 30,
+        }),
+        buildTaskEdge({ id: "T5", taskPath: ":epsilon", durationMs: 2 }),
+      ]);
+      const instance = graphInstance();
+
+      instance.emitNode("node:click", "T5");
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()?.mode).toBe("selected");
+      expect(elementState(instance, "T5")).toEqual(["highlighted", "selected"]);
+
+      component.toggleCriticalPath();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()?.mode).toBe("critical");
+      expect(instance.elementStates).toMatchObject({
+        T1: ["critical"],
+        T2: ["critical"],
+        T4: ["critical"],
+        T3: ["dimmed"],
+        T5: ["dimmed"],
+        "T1:T2": ["critical"],
+        "T2:T4": ["critical"],
+      } satisfies ElementStateMap);
+      expect(elementState(instance, "T5")).not.toContain("selected");
+
+      component.toggleCriticalPath();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      expect(component.highlightState()?.mode).toBe("selected");
+      expect(component.highlightState()?.activeNodeId).toBe("T5");
+      expect(elementState(instance, "T5")).toEqual(["highlighted", "selected"]);
+      expect(elementState(instance, "T1")).toEqual(["dimmed"]);
+      expect(elementState(instance, "T1:T2")).toEqual(["dimmed"]);
+    });
   });
 
   describe("template rendering", () => {
@@ -786,6 +860,23 @@ describe("TaskDependencyGraphComponent", () => {
       expect(card.textContent).toContain("3 nodes · 2 edges");
       expect(card.textContent).not.toContain("Timeline");
       expect(card.querySelector("svg")).toBeNull();
+
+      const toggle = card.querySelector(
+        '[data-testid="task-critical-path-toggle"]',
+      ) as HTMLButtonElement;
+      expect(toggle).toBeTruthy();
+      expect(toggle.getAttribute("aria-pressed")).toBe("false");
+      expect(toggle.textContent?.trim()).toBe("Highlight critical path");
+      expect(
+        card.querySelector('[data-testid="task-critical-path-warning"]'),
+      ).toBeFalsy();
+
+      toggle.click();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+      expect(toggle.getAttribute("aria-pressed")).toBe("true");
+      expect(toggle.textContent?.trim()).toBe("Critical path highlighted");
 
       const container = fixture.nativeElement.querySelector(
         '[data-testid="task-dependency-graph"]',
@@ -826,7 +917,64 @@ describe("TaskDependencyGraphComponent", () => {
           '[data-testid="task-dependency-legend"]',
         ),
       ).toBeFalsy();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="task-critical-path-toggle"]',
+        ),
+      ).toBeFalsy();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="task-critical-path-warning"]',
+        ),
+      ).toBeFalsy();
       expect(g6Mock.MockGraph.instances).toHaveLength(0);
+    });
+
+    it("renders the cycle warning only while critical path mode is enabled", async () => {
+      await render([
+        buildTaskEdge({
+          id: "A",
+          dependencies: ["B"],
+          taskPath: ":a",
+          durationMs: 10,
+        }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":b",
+          durationMs: 20,
+        }),
+      ]);
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="task-critical-path-warning"]',
+        ),
+      ).toBeFalsy();
+
+      const toggle = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-toggle"]',
+      ) as HTMLButtonElement;
+      toggle.click();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      const warning = fixture.nativeElement.querySelector(
+        '[data-testid="task-critical-path-warning"]',
+      ) as HTMLElement;
+      expect(warning).toBeTruthy();
+      expect(warning.textContent).toContain("dependency cycle");
+
+      toggle.click();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="task-critical-path-warning"]',
+        ),
+      ).toBeFalsy();
     });
   });
 });

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
@@ -421,6 +421,37 @@ describe("TaskDependencyGraphComponent", () => {
       expect(component.criticalPathWarning()).toContain("terminal task");
     });
 
+    it("treats duplicate terminal labels as ambiguous target values", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 10 }),
+        buildTaskEdge({ id: "B", taskPath: ":build", durationMs: 20 }),
+      ]);
+
+      expect(component.terminalOptions().map((option) => option.label)).toEqual([
+        ":build",
+        ":build",
+      ]);
+
+      component.selectCriticalPathTarget(":build");
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.targetInputValue()).toBe(":build");
+      expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
+      expect(component.criticalPathTargetInputInvalid()).toBe(true);
+      expect(component.criticalPathTargetHelpText()).toContain(
+        "exactly one terminal task",
+      );
+
+      component.showCriticalPath.set(true);
+
+      expect(component.highlightState()).toBeNull();
+      expect(component.criticalPathWarning()).toContain(
+        "exactly one terminal task",
+      );
+    });
+
     it("handles zero, multiple, missing, non-terminal, and terminal requested-task preselection cases", async () => {
       await render([
         buildTaskEdge({ id: "A", taskPath: ":build" }),
@@ -1319,7 +1350,9 @@ describe("TaskDependencyGraphComponent", () => {
       const help = fixture.nativeElement.querySelector(
         '[data-testid="task-critical-path-target-help"]',
       ) as HTMLElement;
-      expect(help.textContent).toContain("Value must match a terminal task");
+      expect(help.textContent).toContain(
+        "Value must match exactly one terminal task",
+      );
       expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
 
       component.toggleCriticalPath();

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
@@ -247,6 +247,18 @@ describe("TaskDependencyGraphComponent", () => {
     return size;
   }
 
+  function highlightedNodeIds(): string[] {
+    return [
+      ...(component.highlightState()?.highlightedNodeIds ?? new Set<string>()),
+    ].sort();
+  }
+
+  function highlightedEdgeKeys(): string[] {
+    return [
+      ...(component.highlightState()?.highlightedEdgeKeys ?? new Set<string>()),
+    ].sort();
+  }
+
   describe("graph data construction", () => {
     it("builds sorted labeled nodes and deduplicated dependency edges", async () => {
       await render([
@@ -345,6 +357,157 @@ describe("TaskDependencyGraphComponent", () => {
 
       component.selectNode("T4");
       expect(component.highlightState()).toBeNull();
+    });
+  });
+
+  describe("critical path state", () => {
+    it("computes a critical path through dependency edge direction", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 10 }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":b",
+          durationMs: 20,
+        }),
+        buildTaskEdge({
+          id: "C",
+          dependencies: ["B"],
+          taskPath: ":c",
+          durationMs: 30,
+        }),
+      ]);
+
+      component.showCriticalPath.set(true);
+
+      expect(component.highlightState()?.mode).toBe("critical");
+      expect(highlightedNodeIds()).toEqual(["A", "B", "C"]);
+      expect(highlightedEdgeKeys()).toEqual(["A:B", "B:C"]);
+      expect(component.criticalPathHasCycle()).toBe(false);
+    });
+
+    it("chooses the global longest cumulative path in disconnected graphs", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 100 }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":b",
+          durationMs: 1,
+        }),
+        buildTaskEdge({ id: "C", taskPath: ":c", durationMs: 10 }),
+        buildTaskEdge({
+          id: "D",
+          dependencies: ["C"],
+          taskPath: ":d",
+          durationMs: 10,
+        }),
+        buildTaskEdge({
+          id: "E",
+          dependencies: ["D"],
+          taskPath: ":e",
+          durationMs: 10,
+        }),
+      ]);
+
+      component.showCriticalPath.set(true);
+
+      expect(highlightedNodeIds()).toEqual(["A", "B"]);
+      expect(highlightedEdgeKeys()).toEqual(["A:B"]);
+    });
+
+    it("breaks equal-score ties with the lexicographically smallest full node-id path", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 5 }),
+        buildTaskEdge({ id: "B", taskPath: ":b", durationMs: 5 }),
+        buildTaskEdge({
+          id: "C",
+          dependencies: ["A", "B"],
+          taskPath: ":c",
+          durationMs: 5,
+        }),
+      ]);
+
+      component.showCriticalPath.set(true);
+
+      expect(highlightedNodeIds()).toEqual(["A", "C"]);
+      expect(highlightedEdgeKeys()).toEqual(["A:C"]);
+    });
+
+    it("treats null durations as zero", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: null }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":b",
+          durationMs: 10,
+        }),
+        buildTaskEdge({ id: "C", taskPath: ":c", durationMs: 9 }),
+      ]);
+
+      component.showCriticalPath.set(true);
+
+      expect(highlightedNodeIds()).toEqual(["A", "B"]);
+      expect(highlightedEdgeKeys()).toEqual(["A:B"]);
+    });
+
+    it("chooses the highest-duration isolated node and ties by node id", async () => {
+      await render([
+        buildTaskEdge({ id: "B", taskPath: ":b", durationMs: 20 }),
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 20 }),
+        buildTaskEdge({ id: "C", taskPath: ":c", durationMs: 10 }),
+      ]);
+
+      component.showCriticalPath.set(true);
+
+      expect(highlightedNodeIds()).toEqual(["A"]);
+      expect(highlightedEdgeKeys()).toEqual([]);
+    });
+
+    it("returns no critical highlight and exposes a warning for cyclic graph data", async () => {
+      await render([
+        buildTaskEdge({
+          id: "A",
+          dependencies: ["B"],
+          taskPath: ":a",
+          durationMs: 10,
+        }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":b",
+          durationMs: 20,
+        }),
+      ]);
+
+      component.showCriticalPath.set(true);
+
+      expect(component.highlightState()).toBeNull();
+      expect(component.criticalPathHasCycle()).toBe(true);
+    });
+
+    it("keeps selected-node state intact while critical-path mode is toggled", async () => {
+      await render([
+        buildTaskEdge({ id: "T1", taskPath: ":alpha", durationMs: 10 }),
+        buildTaskEdge({
+          id: "T2",
+          dependencies: ["T1"],
+          taskPath: ":beta",
+          durationMs: 20,
+        }),
+      ]);
+
+      component.selectNode("T2");
+      expect(component.highlightState()?.mode).toBe("selected");
+      expect(component.highlightState()?.activeNodeId).toBe("T2");
+
+      component.showCriticalPath.set(true);
+      expect(component.highlightState()?.mode).toBe("critical");
+
+      component.showCriticalPath.set(false);
+      expect(component.highlightState()?.mode).toBe("selected");
+      expect(component.highlightState()?.activeNodeId).toBe("T2");
     });
   });
 

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
@@ -400,9 +400,7 @@ export class TaskDependencyGraphComponent {
     const targetInputValue = this.targetInputValue();
     return (
       targetInputValue.length > 0 &&
-      !this.terminalOptions().some(
-        (option) => option.label === targetInputValue,
-      )
+      this.matchingTerminalOptions(targetInputValue).length !== 1
     );
   });
   readonly criticalPathTargetHelpText = computed(() => {
@@ -410,7 +408,7 @@ export class TaskDependencyGraphComponent {
       return "No terminal tasks are available for this graph.";
     }
     if (this.criticalPathTargetInputInvalid()) {
-      return "Value must match a terminal task.";
+      return "Value must match exactly one terminal task.";
     }
     return "Choose a terminal task to inspect critical path candidates.";
   });
@@ -609,11 +607,12 @@ export class TaskDependencyGraphComponent {
     const pendingNodeIds = nodeIds.filter(
       (nodeId) => (incomingCounts.get(nodeId) ?? 0) === 0,
     );
+    let pendingNodeIndex = 0;
     let processedNodeCount = 0;
 
-    while (pendingNodeIds.length > 0) {
-      const sourceId = pendingNodeIds.shift();
-      if (!sourceId) continue;
+    while (pendingNodeIndex < pendingNodeIds.length) {
+      const sourceId = pendingNodeIds[pendingNodeIndex];
+      pendingNodeIndex += 1;
       processedNodeCount += 1;
 
       const sourceCandidate = bestByNodeId.get(sourceId);
@@ -639,7 +638,6 @@ export class TaskDependencyGraphComponent {
         );
         if ((incomingCounts.get(edge.targetId) ?? 0) === 0) {
           pendingNodeIds.push(edge.targetId);
-          pendingNodeIds.sort((left, right) => left.localeCompare(right));
         }
       }
     }
@@ -696,7 +694,7 @@ export class TaskDependencyGraphComponent {
     }
 
     if (this.criticalPathTargetInputInvalid()) {
-      return "Critical path highlighting is unavailable because the target must match a terminal task.";
+      return "Critical path highlighting is unavailable because the target must match exactly one terminal task.";
     }
 
     if (!this.effectiveCriticalPathTargetNodeId()) {
@@ -830,10 +828,14 @@ export class TaskDependencyGraphComponent {
   selectCriticalPathTarget(typedValue: string | null): void {
     this.userModifiedTarget.set(true);
     this.targetInputValue.set(typedValue ?? "");
-    const match = this.terminalOptions().find(
-      (option) => option.label === typedValue,
+    const matches = this.matchingTerminalOptions(typedValue ?? "");
+    this.selectedTerminalNodeId.set(
+      matches.length === 1 ? (matches[0]?.nodeId ?? null) : null,
     );
-    this.selectedTerminalNodeId.set(match?.nodeId ?? null);
+  }
+
+  private matchingTerminalOptions(label: string): CriticalPathTargetOption[] {
+    return this.terminalOptions().filter((option) => option.label === label);
   }
 
   private isTerminalNodeId(nodeId: string): boolean {

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
@@ -137,6 +137,11 @@ const FALLBACK_STYLE = {
   strokeColor: "oklch(55% 0.04 260)",
 };
 
+const CRITICAL_STYLE = {
+  strokeColor: "oklch(72% 0.18 70)",
+  shadowColor: "oklch(72% 0.18 70 / 0.72)",
+};
+
 const LEGEND_NODE_ITEMS: LegendNodeItem[] = [
   { label: "Success", ...SUCCESS_STYLE },
   { label: "From Cache", ...FROM_CACHE_STYLE },
@@ -239,9 +244,26 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
             </p>
           </div>
           @if (graph().nodes.length > 0) {
-            <div class="text-xs opacity-60">
-              {{ graph().nodes.length }} nodes ·
-              {{ graph().edges.length }} edges
+            <div class="flex flex-col items-end gap-2 text-right">
+              <button
+                data-testid="task-critical-path-toggle"
+                type="button"
+                class="btn btn-sm border-base-300 shadow-none"
+                [class.btn-warning]="showCriticalPath()"
+                [class.btn-outline]="!showCriticalPath()"
+                [attr.aria-pressed]="showCriticalPath()"
+                (click)="toggleCriticalPath()"
+              >
+                @if (showCriticalPath()) {
+                  Critical path highlighted
+                } @else {
+                  Highlight critical path
+                }
+              </button>
+              <div class="text-xs opacity-60">
+                {{ graph().nodes.length }} nodes ·
+                {{ graph().edges.length }} edges
+              </div>
             </div>
           }
         </div>
@@ -269,6 +291,16 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
               <span>Task dependency</span>
             </div>
           </div>
+
+          @if (criticalPathHasCycle()) {
+            <div
+              data-testid="task-critical-path-warning"
+              class="mb-3 rounded-box border border-warning/40 bg-warning/10 px-3 py-2 text-sm text-warning"
+            >
+              Critical path highlighting is unavailable because this graph
+              contains a dependency cycle.
+            </div>
+          }
 
           <div
             class="overflow-hidden rounded-box border border-base-300 bg-base-100/40 p-3"
@@ -625,9 +657,20 @@ export class TaskDependencyGraphComponent {
     this.selectedNodeId.set(null);
   }
 
-  nodeHighlightState(nodeId: string): "idle" | "highlighted" | "dimmed" {
+  toggleCriticalPath(): void {
+    this.showCriticalPath.update((isShown) => !isShown);
+  }
+
+  nodeHighlightState(
+    nodeId: string,
+  ): "idle" | "highlighted" | "critical" | "dimmed" {
     const highlightState = this.highlightState();
     if (!highlightState) return "idle";
+    if (highlightState.mode === "critical") {
+      return highlightState.highlightedNodeIds.has(nodeId)
+        ? "critical"
+        : "dimmed";
+    }
     return highlightState.highlightedNodeIds.has(nodeId)
       ? "highlighted"
       : "dimmed";
@@ -635,12 +678,14 @@ export class TaskDependencyGraphComponent {
 
   edgeHighlightState(
     edge: TaskDependencyEdge,
-  ): "idle" | "highlighted" | "dimmed" {
+  ): "idle" | "highlighted" | "critical" | "dimmed" {
     const highlightState = this.highlightState();
     if (!highlightState) return "idle";
-    return highlightState.highlightedEdgeKeys.has(edgeKey(edge))
-      ? "highlighted"
-      : "dimmed";
+    const isHighlighted = highlightState.highlightedEdgeKeys.has(edgeKey(edge));
+    if (highlightState.mode === "critical") {
+      return isHighlighted ? "critical" : "dimmed";
+    }
+    return isHighlighted ? "highlighted" : "dimmed";
   }
 
   private async renderG6Graph(
@@ -700,6 +745,12 @@ export class TaskDependencyGraphComponent {
           selected: {
             lineWidth: 4,
           },
+          critical: {
+            stroke: CRITICAL_STYLE.strokeColor,
+            lineWidth: 5,
+            shadowBlur: 18,
+            shadowColor: CRITICAL_STYLE.shadowColor,
+          },
           dimmed: {
             opacity: 0.28,
             labelOpacity: 0.36,
@@ -714,6 +765,11 @@ export class TaskDependencyGraphComponent {
         state: {
           highlighted: {
             lineWidth: 3,
+            opacity: 1,
+          },
+          critical: {
+            stroke: CRITICAL_STYLE.strokeColor,
+            lineWidth: 5,
             opacity: 1,
           },
           dimmed: {
@@ -758,7 +814,9 @@ export class TaskDependencyGraphComponent {
 
     for (const nodeId of graphData.nodeIds) {
       const state = this.nodeHighlightState(nodeId);
-      if (state === "highlighted") {
+      if (state === "critical") {
+        states[nodeId] = ["critical"];
+      } else if (state === "highlighted") {
         states[nodeId] =
           highlightState?.mode === "selected" &&
           highlightState.activeNodeId === nodeId

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
@@ -44,9 +44,20 @@ interface TaskDependencyEdge {
 
 interface TaskDependencyHighlightState {
   activeNodeId: string;
-  mode: "selected";
+  mode: "selected" | "critical";
   highlightedNodeIds: ReadonlySet<string>;
   highlightedEdgeKeys: ReadonlySet<string>;
+}
+
+interface TaskDependencyCriticalPathState {
+  nodeIds: ReadonlySet<string>;
+  edgeKeys: ReadonlySet<string>;
+  hasCycle: boolean;
+}
+
+interface CriticalPathCandidate {
+  score: number;
+  path: string[];
 }
 
 interface LegendNodeItem {
@@ -142,6 +153,28 @@ function truncateTaskLabel(label: string): string {
 
 function edgeKey(edge: TaskDependencyEdge): string {
   return `${edge.sourceId}:${edge.targetId}`;
+}
+
+function compareNodeIdPaths(
+  left: readonly string[],
+  right: readonly string[],
+): number {
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const delta = left[index].localeCompare(right[index]);
+    if (delta !== 0) return delta;
+  }
+  return left.length - right.length;
+}
+
+function isBetterCriticalPathCandidate(
+  candidate: CriticalPathCandidate,
+  current: CriticalPathCandidate,
+): boolean {
+  if (candidate.score !== current.score) {
+    return candidate.score > current.score;
+  }
+  return compareNodeIdPaths(candidate.path, current.path) < 0;
 }
 
 function buildIncomingDependencyCounts(
@@ -267,6 +300,7 @@ export class TaskDependencyGraphComponent {
   private renderRequestId = 0;
   private hasSyncedActiveElementStates = false;
   private selectedNodeId = signal<string | null>(null);
+  showCriticalPath = signal(false);
   private selectedNodeIdInGraph = computed(() => {
     const selectedNodeId = this.selectedNodeId();
     if (!selectedNodeId) return null;
@@ -362,6 +396,119 @@ export class TaskDependencyGraphComponent {
     return { nodes, edges };
   });
 
+  private criticalPathState = computed<TaskDependencyCriticalPathState>(() => {
+    const graph = this.graph();
+    const nodeIds = graph.nodes.map((node) => node.id).sort();
+    if (nodeIds.length === 0) {
+      return {
+        nodeIds: new Set<string>(),
+        edgeKeys: new Set<string>(),
+        hasCycle: false,
+      };
+    }
+
+    const durationsByNodeId = new Map(
+      graph.nodes.map((node) => [node.id, node.durationMs ?? 0]),
+    );
+    const outgoingEdgesBySource = new Map<string, TaskDependencyEdge[]>();
+    const incomingCounts = new Map<string, number>();
+    const bestByNodeId = new Map<string, CriticalPathCandidate>();
+
+    for (const nodeId of nodeIds) {
+      incomingCounts.set(nodeId, 0);
+      bestByNodeId.set(nodeId, {
+        score: durationsByNodeId.get(nodeId) ?? 0,
+        path: [nodeId],
+      });
+    }
+
+    for (const edge of graph.edges) {
+      const outgoingEdges = outgoingEdgesBySource.get(edge.sourceId) ?? [];
+      outgoingEdges.push(edge);
+      outgoingEdgesBySource.set(edge.sourceId, outgoingEdges);
+      incomingCounts.set(
+        edge.targetId,
+        (incomingCounts.get(edge.targetId) ?? 0) + 1,
+      );
+    }
+
+    for (const outgoingEdges of outgoingEdgesBySource.values()) {
+      outgoingEdges.sort((left, right) => {
+        const sourceDelta = left.sourceId.localeCompare(right.sourceId);
+        return sourceDelta !== 0
+          ? sourceDelta
+          : left.targetId.localeCompare(right.targetId);
+      });
+    }
+
+    const pendingNodeIds = nodeIds.filter(
+      (nodeId) => (incomingCounts.get(nodeId) ?? 0) === 0,
+    );
+    let processedNodeCount = 0;
+
+    while (pendingNodeIds.length > 0) {
+      const sourceId = pendingNodeIds.shift();
+      if (!sourceId) continue;
+      processedNodeCount += 1;
+
+      const sourceCandidate = bestByNodeId.get(sourceId);
+      if (!sourceCandidate) continue;
+
+      for (const edge of outgoingEdgesBySource.get(sourceId) ?? []) {
+        const targetCandidate = bestByNodeId.get(edge.targetId);
+        const candidate = {
+          score:
+            sourceCandidate.score + (durationsByNodeId.get(edge.targetId) ?? 0),
+          path: [...sourceCandidate.path, edge.targetId],
+        };
+        if (
+          !targetCandidate ||
+          isBetterCriticalPathCandidate(candidate, targetCandidate)
+        ) {
+          bestByNodeId.set(edge.targetId, candidate);
+        }
+
+        incomingCounts.set(
+          edge.targetId,
+          (incomingCounts.get(edge.targetId) ?? 0) - 1,
+        );
+        if ((incomingCounts.get(edge.targetId) ?? 0) === 0) {
+          pendingNodeIds.push(edge.targetId);
+          pendingNodeIds.sort((left, right) => left.localeCompare(right));
+        }
+      }
+    }
+
+    if (processedNodeCount < nodeIds.length) {
+      return {
+        nodeIds: new Set<string>(),
+        edgeKeys: new Set<string>(),
+        hasCycle: true,
+      };
+    }
+
+    const bestPath = [...bestByNodeId.values()].reduce(
+      (currentBest, candidate) =>
+        isBetterCriticalPathCandidate(candidate, currentBest)
+          ? candidate
+          : currentBest,
+    );
+    const edgeKeys = new Set<string>();
+    for (let index = 1; index < bestPath.path.length; index += 1) {
+      edgeKeys.add(`${bestPath.path[index - 1]}:${bestPath.path[index]}`);
+    }
+
+    return {
+      nodeIds: new Set(bestPath.path),
+      edgeKeys,
+      hasCycle: false,
+    };
+  });
+
+  criticalPathHasCycle = computed(
+    () => this.showCriticalPath() && this.criticalPathState().hasCycle,
+  );
+
   private g6GraphData = computed<G6TaskGraphData>(() => {
     const graph = this.graph();
     const incomingCounts = buildIncomingDependencyCounts(graph.edges);
@@ -420,6 +567,18 @@ export class TaskDependencyGraphComponent {
   });
 
   highlightState = computed<TaskDependencyHighlightState | null>(() => {
+    if (this.showCriticalPath()) {
+      const criticalPath = this.criticalPathState();
+      const [activeNodeId] = criticalPath.nodeIds;
+      if (criticalPath.hasCycle || !activeNodeId) return null;
+      return {
+        activeNodeId,
+        mode: "critical",
+        highlightedNodeIds: criticalPath.nodeIds,
+        highlightedEdgeKeys: criticalPath.edgeKeys,
+      };
+    }
+
     const activeNodeId = this.selectedNodeIdInGraph();
     if (!activeNodeId) return null;
 

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
@@ -49,21 +49,9 @@ interface TaskDependencyHighlightState {
   highlightedEdgeKeys: ReadonlySet<string>;
 }
 
-interface TaskDependencyCriticalPathState {
-  nodeIds: ReadonlySet<string>;
-  edgeKeys: ReadonlySet<string>;
-  hasCycle: boolean;
-}
-
-interface CriticalPathCandidate {
-  score: number;
-  path: string[];
-}
-
-interface LegendNodeItem {
+interface CriticalPathTargetOption {
+  nodeId: string;
   label: string;
-  fillColor: string;
-  strokeColor: string;
 }
 
 interface G6TaskGraphData {
@@ -71,6 +59,23 @@ interface G6TaskGraphData {
   key: string;
   nodeIds: string[];
   edgeIds: string[];
+}
+
+interface CriticalPathCandidate {
+  score: number;
+  path: string[];
+}
+
+interface TaskDependencyCriticalPathState {
+  nodeIds: ReadonlySet<string>;
+  edgeKeys: ReadonlySet<string>;
+  hasCycle: boolean;
+}
+
+interface LegendNodeItem {
+  label: string;
+  fillColor: string;
+  strokeColor: string;
 }
 
 interface TaskGraphLayoutOptions extends Record<string, unknown> {
@@ -245,6 +250,44 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
           </div>
           @if (graph().nodes.length > 0) {
             <div class="flex flex-col items-end gap-2 text-right">
+              <div class="flex flex-col items-end gap-1">
+                <label
+                  class="text-xs font-medium uppercase tracking-wide opacity-70"
+                  for="task-critical-path-target-input"
+                >
+                  Critical path target
+                </label>
+                <input
+                  id="task-critical-path-target-input"
+                  data-testid="task-critical-path-target-input"
+                  type="text"
+                  list="task-critical-path-target-options"
+                  class="input input-sm input-bordered w-64 max-w-full font-mono text-xs"
+                  [value]="targetInputValue()"
+                  [disabled]="terminalOptions().length === 0"
+                  [attr.aria-describedby]="'task-critical-path-target-help'"
+                  [attr.aria-invalid]="criticalPathTargetInputInvalid()"
+                  (input)="selectCriticalPathTarget($any($event.target).value)"
+                  (change)="selectCriticalPathTarget($any($event.target).value)"
+                />
+                <datalist
+                  id="task-critical-path-target-options"
+                  data-testid="task-critical-path-target-options"
+                >
+                  @for (option of terminalOptions(); track option.nodeId) {
+                    <option [value]="option.label"></option>
+                  }
+                </datalist>
+                <p
+                  id="task-critical-path-target-help"
+                  data-testid="task-critical-path-target-help"
+                  class="max-w-64 text-xs"
+                  [class.opacity-60]="!criticalPathTargetInputInvalid()"
+                  [class.text-error]="criticalPathTargetInputInvalid()"
+                >
+                  {{ criticalPathTargetHelpText() }}
+                </p>
+              </div>
               <button
                 data-testid="task-critical-path-toggle"
                 type="button"
@@ -292,13 +335,12 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
             </div>
           </div>
 
-          @if (criticalPathHasCycle()) {
+          @if (criticalPathWarning()) {
             <div
               data-testid="task-critical-path-warning"
               class="mb-3 rounded-box border border-warning/40 bg-warning/10 px-3 py-2 text-sm text-warning"
             >
-              Critical path highlighting is unavailable because this graph
-              contains a dependency cycle.
+              {{ criticalPathWarning() }}
             </div>
           }
 
@@ -320,6 +362,7 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
 })
 export class TaskDependencyGraphComponent {
   taskEdges = input.required<TaskEdge[]>();
+  readonly requestedTasks = input<readonly string[]>([]);
   legendNodeItems = LEGEND_NODE_ITEMS;
   readonly edgeKey = edgeKey;
 
@@ -332,7 +375,66 @@ export class TaskDependencyGraphComponent {
   private renderRequestId = 0;
   private hasSyncedActiveElementStates = false;
   private selectedNodeId = signal<string | null>(null);
+  readonly targetInputValue = signal<string>("");
+  private selectedTerminalNodeId = signal<string | null>(null);
+  private userModifiedTarget = signal(false);
   showCriticalPath = signal(false);
+  readonly terminalOptions = computed<CriticalPathTargetOption[]>(() => {
+    const graph = this.graph();
+    const sourceNodeIds = new Set(graph.edges.map((edge) => edge.sourceId));
+    return graph.nodes
+      .filter((node) => !sourceNodeIds.has(node.id))
+      .map((node) => ({
+        nodeId: node.id,
+        label: node.label,
+      }));
+  });
+  readonly effectiveCriticalPathTargetNodeId = computed(() => {
+    const selectedTerminalNodeId = this.selectedTerminalNodeId();
+    return selectedTerminalNodeId &&
+      this.isTerminalNodeId(selectedTerminalNodeId)
+      ? selectedTerminalNodeId
+      : null;
+  });
+  readonly criticalPathTargetInputInvalid = computed(() => {
+    const targetInputValue = this.targetInputValue();
+    return (
+      targetInputValue.length > 0 &&
+      !this.terminalOptions().some(
+        (option) => option.label === targetInputValue,
+      )
+    );
+  });
+  readonly criticalPathTargetHelpText = computed(() => {
+    if (this.terminalOptions().length === 0) {
+      return "No terminal tasks are available for this graph.";
+    }
+    if (this.criticalPathTargetInputInvalid()) {
+      return "Value must match a terminal task.";
+    }
+    return "Choose a terminal task to inspect critical path candidates.";
+  });
+  private requestedTaskPreselection = computed(() => {
+    const requestedTasks = this.requestedTasks();
+    if (requestedTasks.length !== 1) return null;
+    const requestedTask = requestedTasks[0];
+    if (!requestedTask) return null;
+
+    const terminalOptions = this.terminalOptions();
+    const exactMatches = terminalOptions.filter(
+      (option) => option.label === requestedTask,
+    );
+    if (exactMatches.length === 1) return exactMatches[0]?.nodeId ?? null;
+
+    if (requestedTask.startsWith(":")) return null;
+
+    const normalizedMatches = terminalOptions.filter(
+      (option) => option.label === `:${requestedTask}`,
+    );
+    return normalizedMatches.length === 1
+      ? (normalizedMatches[0]?.nodeId ?? null)
+      : null;
+  });
   private selectedNodeIdInGraph = computed(() => {
     const selectedNodeId = this.selectedNodeId();
     if (!selectedNodeId) return null;
@@ -347,6 +449,37 @@ export class TaskDependencyGraphComponent {
     });
 
     afterRenderEffect(() => {
+      const terminalOptions = this.terminalOptions();
+      const selectedTerminalNodeId = this.selectedTerminalNodeId();
+      const selectedTerminalLabel = terminalOptions.find(
+        (option) => option.nodeId === selectedTerminalNodeId,
+      )?.label;
+      const requestedTaskPreselection = this.requestedTaskPreselection();
+
+      if (
+        selectedTerminalNodeId &&
+        !terminalOptions.some(
+          (option) => option.nodeId === selectedTerminalNodeId,
+        )
+      ) {
+        this.selectedTerminalNodeId.set(null);
+        if (this.targetInputValue() === selectedTerminalLabel) {
+          this.targetInputValue.set("");
+        }
+      }
+
+      if (!this.userModifiedTarget() && requestedTaskPreselection) {
+        this.selectedTerminalNodeId.set(requestedTaskPreselection);
+        this.targetInputValue.set(
+          terminalOptions.find(
+            (option) => option.nodeId === requestedTaskPreselection,
+          )?.label ?? "",
+        );
+      } else if (!this.userModifiedTarget() && !requestedTaskPreselection) {
+        this.selectedTerminalNodeId.set(null);
+        this.targetInputValue.set("");
+      }
+
       if (this.selectedNodeId() && !this.selectedNodeIdInGraph()) {
         this.selectedNodeId.set(null);
       }
@@ -519,12 +652,23 @@ export class TaskDependencyGraphComponent {
       };
     }
 
-    const bestPath = [...bestByNodeId.values()].reduce(
-      (currentBest, candidate) =>
-        isBetterCriticalPathCandidate(candidate, currentBest)
-          ? candidate
-          : currentBest,
-    );
+    const terminalNodeId = this.effectiveCriticalPathTargetNodeId();
+    if (!terminalNodeId) {
+      return {
+        nodeIds: new Set<string>(),
+        edgeKeys: new Set<string>(),
+        hasCycle: false,
+      };
+    }
+
+    const bestPath = bestByNodeId.get(terminalNodeId);
+    if (!bestPath) {
+      return {
+        nodeIds: new Set<string>(),
+        edgeKeys: new Set<string>(),
+        hasCycle: false,
+      };
+    }
     const edgeKeys = new Set<string>();
     for (let index = 1; index < bestPath.path.length; index += 1) {
       edgeKeys.add(`${bestPath.path[index - 1]}:${bestPath.path[index]}`);
@@ -540,6 +684,27 @@ export class TaskDependencyGraphComponent {
   criticalPathHasCycle = computed(
     () => this.showCriticalPath() && this.criticalPathState().hasCycle,
   );
+
+  criticalPathWarning = computed(() => {
+    if (!this.showCriticalPath()) {
+      return null;
+    }
+
+    const criticalPathState = this.criticalPathState();
+    if (criticalPathState.hasCycle) {
+      return "Critical path highlighting is unavailable because this graph contains a dependency cycle.";
+    }
+
+    if (this.criticalPathTargetInputInvalid()) {
+      return "Critical path highlighting is unavailable because the target must match a terminal task.";
+    }
+
+    if (!this.effectiveCriticalPathTargetNodeId()) {
+      return "Critical path highlighting is unavailable because you must choose a terminal task from the selector.";
+    }
+
+    return null;
+  });
 
   private g6GraphData = computed<G6TaskGraphData>(() => {
     const graph = this.graph();
@@ -600,6 +765,7 @@ export class TaskDependencyGraphComponent {
 
   highlightState = computed<TaskDependencyHighlightState | null>(() => {
     if (this.showCriticalPath()) {
+      if (this.criticalPathTargetInputInvalid()) return null;
       const criticalPath = this.criticalPathState();
       const [activeNodeId] = criticalPath.nodeIds;
       if (criticalPath.hasCycle || !activeNodeId) return null;
@@ -659,6 +825,19 @@ export class TaskDependencyGraphComponent {
 
   toggleCriticalPath(): void {
     this.showCriticalPath.update((isShown) => !isShown);
+  }
+
+  selectCriticalPathTarget(typedValue: string | null): void {
+    this.userModifiedTarget.set(true);
+    this.targetInputValue.set(typedValue ?? "");
+    const match = this.terminalOptions().find(
+      (option) => option.label === typedValue,
+    );
+    this.selectedTerminalNodeId.set(match?.nodeId ?? null);
+  }
+
+  private isTerminalNodeId(nodeId: string): boolean {
+    return this.terminalOptions().some((option) => option.nodeId === nodeId);
   }
 
   nodeHighlightState(
@@ -782,10 +961,12 @@ export class TaskDependencyGraphComponent {
 
   private bindGraphEvents(graph: Graph): void {
     graph.on(NodeEvent.CLICK, (event: IElementEvent) => {
+      if (this.showCriticalPath()) return;
       const nodeId = getNodeIdFromEvent(event);
       if (nodeId) this.selectNode(nodeId);
     });
     graph.on(CanvasEvent.CLICK, () => {
+      if (this.showCriticalPath()) return;
       this.clearSelectedNode();
     });
   }


### PR DESCRIPTION
## Summary
- Add a native terminal-task selector for task dependency graph critical-path highlighting.
- Anchor critical-path computation to the selected terminal task while keeping graph-click upstream inspection independent.
- Pass requested Gradle tasks into the graph so a single terminal requested task can preselect the target.

## Verification
- bazel run gazelle
- bazel run //tools/format
- aspect lint //...
- aspect test //...
- aspect build //...
- Browser QA against local scan `6083c771-f2d2-47da-a267-20a6a4dcec4b`