### PR TITLE
feat: separate critical path graph

### DIFF
--- a/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.spec.ts
@@ -121,6 +121,7 @@ describe("ScanTasksTabComponent", () => {
       fixture.nativeElement.querySelector("app-task-dependency-graph"),
     ).toBeTruthy();
     expect(fixture.nativeElement.textContent).toContain("Task Dependencies");
+    expect(fixture.nativeElement.textContent).toContain("Critical Path");
     expect(fixture.nativeElement.querySelector("app-tasks-table")).toBeTruthy();
     expect(fixture.nativeElement.querySelectorAll("tbody tr").length).toBe(1);
   });
@@ -204,10 +205,16 @@ describe("ScanTasksTabComponent", () => {
 
     expect(
       largeFixture.nativeElement.querySelector("app-task-dependency-graph"),
-    ).toBeNull();
+    ).toBeTruthy();
+    expect(
+      largeFixture.nativeElement.querySelector(
+        "[data-testid='task-dependency-graph-hidden']",
+      ),
+    ).toBeTruthy();
     expect(largeFixture.nativeElement.textContent).toContain(
       "Task dependency graph hidden",
     );
+    expect(largeFixture.nativeElement.textContent).toContain("Critical Path");
 
     const buttons = Array.from(
       (largeFixture.nativeElement as HTMLElement).querySelectorAll("button"),
@@ -224,6 +231,15 @@ describe("ScanTasksTabComponent", () => {
     expect(
       largeFixture.nativeElement.querySelector("app-task-dependency-graph"),
     ).toBeTruthy();
+    expect(
+      largeFixture.nativeElement.querySelector(
+        "[data-testid='task-dependency-graph-hidden']",
+      ),
+    ).toBeNull();
+    expect(largeFixture.nativeElement.textContent).toContain("Critical Path");
+    expect(largeFixture.nativeElement.textContent).not.toContain(
+      "Task dependency graph hidden",
+    );
 
     largeFixture.destroy();
   });

--- a/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/scan-tasks-tab.component.ts
@@ -145,12 +145,13 @@ const GET_SCAN_TASKS = gql`
           [loading]="loading()"
         />
 
-        @if (showDependencyGraph()) {
-          <app-task-dependency-graph
-            [taskEdges]="taskEdges()"
-            [requestedTasks]="requestedTasks()"
-          />
-        } @else if (hasLargeTaskGraph()) {
+        <app-task-dependency-graph
+          [taskEdges]="taskEdges()"
+          [requestedTasks]="requestedTasks()"
+          [hiddenForLargeGraph]="hasLargeTaskGraph() && !renderLargeGraph()"
+        />
+
+        @if (hasLargeTaskGraph() && !renderLargeGraph()) {
           <div
             class="rounded-md border border-base-300 bg-base-200 p-4 text-sm"
           >
@@ -195,9 +196,6 @@ export class ScanTasksTabComponent implements OnInit {
   renderLargeGraph = signal(false);
   hasLargeTaskGraph = computed(
     () => this.taskCount() > LARGE_GRAPH_TASK_THRESHOLD,
-  );
-  showDependencyGraph = computed(
-    () => !this.hasLargeTaskGraph() || this.renderLargeGraph(),
   );
 
   private loadRemainingPages(

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.spec.ts
@@ -247,6 +247,38 @@ describe("TaskDependencyGraphComponent", () => {
     return size;
   }
 
+  function graphNodeIds(
+    instance: InstanceType<typeof g6Mock.MockGraph>,
+  ): string[] {
+    return instance.data.nodes.map((node) => node.id).sort();
+  }
+
+  function graphEdgeIds(
+    instance: InstanceType<typeof g6Mock.MockGraph>,
+  ): string[] {
+    return instance.data.edges.map((edge) => edge.id).sort();
+  }
+
+  function graphEdgeSourcesAndTargets(
+    instance: InstanceType<typeof g6Mock.MockGraph>,
+  ): Array<{ source: string; target: string }> {
+    return instance.data.edges
+      .map((edge) => ({ source: edge.source, target: edge.target }))
+      .sort((left, right) =>
+        `${left.source}:${left.target}`.localeCompare(
+          `${right.source}:${right.target}`,
+        ),
+      );
+  }
+
+  function criticalPathNodeIds(): string[] {
+    return component.criticalPathGraphData().nodeIds.slice().sort();
+  }
+
+  function criticalPathEdgeIds(): string[] {
+    return component.criticalPathGraphData().edgeIds.slice().sort();
+  }
+
   function highlightedNodeIds(): string[] {
     return [
       ...(component.highlightState()?.highlightedNodeIds ?? new Set<string>()),
@@ -398,7 +430,6 @@ describe("TaskDependencyGraphComponent", () => {
       ]);
 
       component.selectCriticalPathTarget(":test");
-      component.showCriticalPath.set(true);
       fixture.detectChanges();
       await settleAsyncWork(fixture);
       fixture.detectChanges();
@@ -406,9 +437,9 @@ describe("TaskDependencyGraphComponent", () => {
       expect(component.targetInputValue()).toBe(":test");
       expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
       expect(component.criticalPathWarning()).toBeNull();
-      expect(component.highlightState()?.mode).toBe("critical");
-      expect(highlightedNodeIds()).toEqual(["A", "B"]);
-      expect(highlightedEdgeKeys()).toEqual(["A:B"]);
+      expect(component.highlightState()).toBeNull();
+      expect(criticalPathNodeIds()).toEqual(["A", "B"]);
+      expect(criticalPathEdgeIds()).toEqual(["A:B"]);
 
       component.selectCriticalPathTarget(":missing");
       fixture.detectChanges();
@@ -421,16 +452,101 @@ describe("TaskDependencyGraphComponent", () => {
       expect(component.criticalPathWarning()).toContain("terminal task");
     });
 
+    it("does not render the full graph as a fallback when the target is invalid or missing", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 50 }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":b",
+          durationMs: 20,
+        }),
+        buildTaskEdge({
+          id: "C",
+          dependencies: ["B"],
+          taskPath: ":c",
+          durationMs: 30,
+        }),
+      ]);
+
+      const initialInstanceCount = g6Mock.MockGraph.instances.length;
+
+      component.selectCriticalPathTarget(":missing");
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.criticalPathWarning()).toContain("terminal task");
+      expect(g6Mock.MockGraph.instances).toHaveLength(initialInstanceCount);
+
+      component.selectCriticalPathTarget(":a");
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.criticalPathWarning()).toContain("terminal task");
+      expect(g6Mock.MockGraph.instances).toHaveLength(initialInstanceCount);
+    });
+
+    it("does not render the full graph as a fallback when the graph contains a cycle", async () => {
+      await render([
+        buildTaskEdge({
+          id: "A",
+          taskPath: ":a",
+          durationMs: 50,
+          dependencies: ["C"],
+        }),
+        buildTaskEdge({
+          id: "B",
+          dependencies: ["A"],
+          taskPath: ":b",
+          durationMs: 20,
+        }),
+        buildTaskEdge({
+          id: "C",
+          dependencies: ["B"],
+          taskPath: ":c",
+          durationMs: 30,
+        }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", [":c"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.criticalPathHasCycle()).toBe(true);
+      expect(component.criticalPathWarning()).toContain("dependency cycle");
+      expect(g6Mock.MockGraph.instances).toHaveLength(1);
+    });
+
+    it("renders a one-node critical path for a terminal task with no dependencies", async () => {
+      await render([
+        buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 50 }),
+      ]);
+
+      fixture.componentRef.setInput("requestedTasks", [":a"]);
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+      fixture.detectChanges();
+
+      expect(component.highlightState()).toBeNull();
+      expect(criticalPathNodeIds()).toEqual(["A"]);
+      expect(criticalPathEdgeIds()).toEqual([]);
+      expect(component.criticalPathHasCycle()).toBe(false);
+      expect(g6Mock.MockGraph.instances).toHaveLength(2);
+      expect(graphNodeIds(graphInstance())).toEqual(["A"]);
+      expect(graphEdgeIds(graphInstance())).toEqual([]);
+    });
     it("treats duplicate terminal labels as ambiguous target values", async () => {
       await render([
         buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 10 }),
         buildTaskEdge({ id: "B", taskPath: ":build", durationMs: 20 }),
       ]);
 
-      expect(component.terminalOptions().map((option) => option.label)).toEqual([
-        ":build",
-        ":build",
-      ]);
+      expect(component.terminalOptions().map((option) => option.label)).toEqual(
+        [":build", ":build"],
+      );
 
       component.selectCriticalPathTarget(":build");
       fixture.detectChanges();
@@ -443,8 +559,6 @@ describe("TaskDependencyGraphComponent", () => {
       expect(component.criticalPathTargetHelpText()).toContain(
         "exactly one terminal task",
       );
-
-      component.showCriticalPath.set(true);
 
       expect(component.highlightState()).toBeNull();
       expect(component.criticalPathWarning()).toContain(
@@ -556,7 +670,7 @@ describe("TaskDependencyGraphComponent", () => {
       expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
     });
 
-    it("computes a critical path through dependency edge direction", async () => {
+    it("computes full and critical path graph datasets for a branched dependency tree", async () => {
       await render([
         buildTaskEdge({ id: "A", taskPath: ":a", durationMs: 80 }),
         buildTaskEdge({
@@ -571,6 +685,12 @@ describe("TaskDependencyGraphComponent", () => {
           taskPath: ":c",
           durationMs: 30,
         }),
+        buildTaskEdge({
+          id: "D",
+          dependencies: ["A"],
+          taskPath: ":d",
+          durationMs: 10,
+        }),
       ]);
 
       fixture.componentRef.setInput("requestedTasks", [":c"]);
@@ -578,12 +698,26 @@ describe("TaskDependencyGraphComponent", () => {
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      component.showCriticalPath.set(true);
-
-      expect(component.highlightState()?.mode).toBe("critical");
-      expect(highlightedNodeIds()).toEqual(["A", "B", "C"]);
-      expect(highlightedEdgeKeys()).toEqual(["A:B", "B:C"]);
+      expect(component.highlightState()).toBeNull();
+      expect(criticalPathNodeIds()).toEqual(["A", "B", "C"]);
+      expect(criticalPathEdgeIds()).toEqual(["A:B", "B:C"]);
       expect(component.criticalPathHasCycle()).toBe(false);
+
+      const instances = g6Mock.MockGraph.instances;
+      expect(instances).toHaveLength(2);
+
+      const fullGraph = instances[0];
+      const criticalPathGraph = instances[1];
+
+      expect(graphNodeIds(fullGraph)).toEqual(["A", "B", "C", "D"]);
+      expect(graphEdgeIds(fullGraph)).toEqual(["A:B", "A:D", "B:C"]);
+      expect(graphEdgeSourcesAndTargets(fullGraph)).toEqual([
+        { source: "A", target: "B" },
+        { source: "A", target: "D" },
+        { source: "B", target: "C" },
+      ]);
+      expect(graphNodeIds(criticalPathGraph)).toEqual(["A", "B", "C"]);
+      expect(graphEdgeIds(criticalPathGraph)).toEqual(["A:B", "B:C"]);
     });
 
     it("highlights only the requested terminal path in disconnected graphs", async () => {
@@ -615,10 +749,8 @@ describe("TaskDependencyGraphComponent", () => {
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      component.showCriticalPath.set(true);
-
-      expect(highlightedNodeIds()).toEqual(["A", "B"]);
-      expect(highlightedEdgeKeys()).toEqual(["A:B"]);
+      expect(criticalPathNodeIds()).toEqual(["A", "B"]);
+      expect(criticalPathEdgeIds()).toEqual(["A:B"]);
     });
 
     it("breaks equal-score ties by the lexicographically smallest terminal path", async () => {
@@ -651,10 +783,8 @@ describe("TaskDependencyGraphComponent", () => {
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      component.showCriticalPath.set(true);
-
-      expect(highlightedNodeIds()).toEqual(["A", "D", "F"]);
-      expect(highlightedEdgeKeys()).toEqual(["A:D", "D:F"]);
+      expect(criticalPathNodeIds()).toEqual(["A", "D", "F"]);
+      expect(criticalPathEdgeIds()).toEqual(["A:D", "D:F"]);
     });
 
     it("treats null durations as zero in terminal critical-path scoring", async () => {
@@ -680,10 +810,8 @@ describe("TaskDependencyGraphComponent", () => {
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      component.showCriticalPath.set(true);
-
-      expect(highlightedNodeIds()).toEqual(["A", "B"]);
-      expect(highlightedEdgeKeys()).toEqual(["A:B"]);
+      expect(criticalPathNodeIds()).toEqual(["A", "B"]);
+      expect(criticalPathEdgeIds()).toEqual(["A:B"]);
     });
 
     it("resolves a single exact taskPath match without normalization", async () => {
@@ -697,10 +825,8 @@ describe("TaskDependencyGraphComponent", () => {
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      component.showCriticalPath.set(true);
-
-      expect(highlightedNodeIds()).toEqual(["A"]);
-      expect(highlightedEdgeKeys()).toEqual([]);
+      expect(criticalPathNodeIds()).toEqual(["A"]);
+      expect(criticalPathEdgeIds()).toEqual([]);
     });
 
     it("normalizes a root task request to a single matching node", async () => {
@@ -716,10 +842,8 @@ describe("TaskDependencyGraphComponent", () => {
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      component.showCriticalPath.set(true);
-
-      expect(highlightedNodeIds()).toEqual(["A"]);
-      expect(highlightedEdgeKeys()).toEqual([]);
+      expect(criticalPathNodeIds()).toEqual(["A"]);
+      expect(criticalPathEdgeIds()).toEqual([]);
     });
 
     it("returns no critical highlight when multiple tasks are requested", async () => {
@@ -732,9 +856,6 @@ describe("TaskDependencyGraphComponent", () => {
       fixture.detectChanges();
       await settleAsyncWork(fixture);
       fixture.detectChanges();
-
-      expect(component.criticalPathWarning()).toBeNull();
-      component.showCriticalPath.set(true);
 
       expect(component.highlightState()).toBeNull();
       expect(component.criticalPathHasCycle()).toBe(false);
@@ -754,12 +875,9 @@ describe("TaskDependencyGraphComponent", () => {
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      expect(component.criticalPathWarning()).toBeNull();
-      component.showCriticalPath.set(true);
-
       expect(component.highlightState()).toBeNull();
-      expect(highlightedNodeIds()).toEqual([]);
-      expect(highlightedEdgeKeys()).toEqual([]);
+      expect(criticalPathNodeIds()).toEqual([]);
+      expect(criticalPathEdgeIds()).toEqual([]);
       expect(component.criticalPathWarning()).toContain(
         "choose a terminal task from the selector",
       );
@@ -797,7 +915,6 @@ describe("TaskDependencyGraphComponent", () => {
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      component.showCriticalPath.set(true);
       fixture.detectChanges();
       await settleAsyncWork(fixture);
       fixture.detectChanges();
@@ -878,22 +995,12 @@ describe("TaskDependencyGraphComponent", () => {
         state: {
           highlighted: expect.objectContaining({ lineWidth: 3 }),
           selected: expect.objectContaining({ lineWidth: 4 }),
-          critical: expect.objectContaining({
-            lineWidth: 5,
-            stroke: expect.any(String),
-            shadowBlur: 18,
-          }),
           dimmed: expect.objectContaining({ opacity: 0.28 }),
         },
       });
       expect(instance.options.edge).toMatchObject({
         state: {
           highlighted: expect.objectContaining({ lineWidth: 3 }),
-          critical: expect.objectContaining({
-            lineWidth: 5,
-            stroke: expect.any(String),
-            opacity: 1,
-          }),
           dimmed: expect.objectContaining({ opacity: 0.12 }),
         },
       });
@@ -1086,7 +1193,7 @@ describe("TaskDependencyGraphComponent", () => {
       expect(elementState(instance, "T6")).toEqual([]);
     });
 
-    it("pushes critical path states into G6 and restores selected states when disabled", async () => {
+    it("keeps selected highlighting confined to the full dependency graph", async () => {
       await render([
         buildTaskEdge({ id: "T1", taskPath: ":alpha", durationMs: 10 }),
         buildTaskEdge({
@@ -1104,95 +1211,40 @@ describe("TaskDependencyGraphComponent", () => {
         }),
         buildTaskEdge({ id: "T5", taskPath: ":epsilon", durationMs: 2 }),
       ]);
-      const instance = graphInstance();
 
       fixture.componentRef.setInput("requestedTasks", [":delta"]);
       fixture.detectChanges();
       await settleAsyncWork(fixture);
       fixture.detectChanges();
 
-      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
-      component.showCriticalPath.set(true);
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("critical");
-      expect(elementState(instance, "T4")).toEqual(["critical"]);
-      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
+      expect(g6Mock.MockGraph.instances).toHaveLength(2);
+      const fullGraph = g6Mock.MockGraph.instances[0];
+      const criticalPathGraph = g6Mock.MockGraph.instances[1];
 
-      component.toggleCriticalPath();
+      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
+      expect(graphNodeIds(criticalPathGraph)).toEqual(["T1", "T2", "T4"]);
+      expect(graphEdgeIds(criticalPathGraph)).toEqual(["T1:T2", "T2:T4"]);
+      expect(criticalPathGraph.elementStates).toEqual({});
+
+      fullGraph.emitNode("node:click", "T5");
       fixture.detectChanges();
       await settleAsyncWork(fixture);
+
+      expect(component.highlightState()?.mode).toBe("selected");
+      expect(elementState(fullGraph, "T5")).toEqual([
+        "highlighted",
+        "selected",
+      ]);
+      expect(elementState(fullGraph, "T1")).toEqual(["dimmed"]);
+      expect(criticalPathGraph.elementStates).toEqual({});
+
+      fullGraph.emitCanvasClick();
+      fixture.detectChanges();
+      await settleAsyncWork(fixture);
+
       expect(component.highlightState()).toBeNull();
-      expect(component.targetInputValue()).toBe(":delta");
-      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
-      expect(elementState(instance, "T5")).toEqual([]);
-
-      component.showCriticalPath.set(true);
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("critical");
-
-      instance.emitNode("node:click", "T5");
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("critical");
-      expect(component.targetInputValue()).toBe(":delta");
-      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
-      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
-
-      instance.emitCanvasClick();
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("critical");
-      expect(component.targetInputValue()).toBe(":delta");
-      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
-      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
-
-      component.toggleCriticalPath();
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()).toBeNull();
-      expect(component.targetInputValue()).toBe(":delta");
-      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
-      expect(elementState(instance, "T5")).toEqual([]);
-
-      component.showCriticalPath.set(true);
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("critical");
-
-      instance.emitNode("node:click", "T5");
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("critical");
-      expect(component.targetInputValue()).toBe(":delta");
-      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
-      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
-
-      component.toggleCriticalPath();
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()).toBeNull();
-      expect(instance.elementStates).toMatchObject({
-        T1: [],
-        T2: [],
-        T4: [],
-        T3: [],
-        T5: [],
-        "T1:T2": [],
-        "T2:T4": [],
-      } satisfies ElementStateMap);
-      expect(elementState(instance, "T5")).not.toContain("selected");
-
-      component.toggleCriticalPath();
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      expect(component.highlightState()?.mode).toBe("critical");
-      expect(component.targetInputValue()).toBe(":delta");
-      expect(component.effectiveCriticalPathTargetNodeId()).toBe("T4");
-      expect(elementState(instance, "T5")).toEqual(["dimmed"]);
-      expect(elementState(instance, "T1")).toEqual(["critical"]);
-      expect(elementState(instance, "T1:T2")).toEqual(["critical"]);
+      expect(elementState(fullGraph, "T5")).toEqual([]);
+      expect(criticalPathGraph.elementStates).toEqual({});
     });
   });
 
@@ -1219,22 +1271,20 @@ describe("TaskDependencyGraphComponent", () => {
       expect(card.textContent).not.toContain("Timeline");
       expect(card.querySelector("svg")).toBeNull();
 
-      const toggle = card.querySelector(
-        '[data-testid="task-critical-path-toggle"]',
-      ) as HTMLButtonElement;
-      expect(toggle).toBeTruthy();
-      expect(toggle.getAttribute("aria-pressed")).toBe("false");
-      expect(toggle.textContent?.trim()).toBe("Highlight critical path");
+      expect(
+        card.querySelector('[data-testid="task-critical-path-toggle"]'),
+      ).toBeFalsy();
+      expect(
+        card.querySelector('[data-testid="task-critical-path-target-input"]'),
+      ).toBeFalsy();
       expect(
         card.querySelector('[data-testid="task-critical-path-warning"]'),
       ).toBeFalsy();
-
-      toggle.click();
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      fixture.detectChanges();
-      expect(toggle.getAttribute("aria-pressed")).toBe("true");
-      expect(toggle.textContent?.trim()).toBe("Critical path highlighted");
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="task-critical-path-warning"]',
+        ),
+      ).toBeTruthy();
 
       const container = fixture.nativeElement.querySelector(
         '[data-testid="task-dependency-graph"]',
@@ -1296,7 +1346,6 @@ describe("TaskDependencyGraphComponent", () => {
 
       expect(component.targetInputValue()).toBe(":test");
       expect(component.effectiveCriticalPathTargetNodeId()).toBe("B");
-      expect(component.showCriticalPath()).toBe(false);
     });
 
     it("disables the terminal target input when no terminal tasks are available", async () => {
@@ -1355,7 +1404,6 @@ describe("TaskDependencyGraphComponent", () => {
       );
       expect(component.effectiveCriticalPathTargetNodeId()).toBeNull();
 
-      component.toggleCriticalPath();
       fixture.detectChanges();
       await settleAsyncWork(fixture);
 
@@ -1393,27 +1441,13 @@ describe("TaskDependencyGraphComponent", () => {
       expect(g6Mock.MockGraph.instances).toHaveLength(0);
     });
 
-    it("renders a terminal warning only after critical path mode is enabled", async () => {
+    it("renders a terminal warning in the Critical Path section when no target is selected", async () => {
       await render([
         buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 10 }),
         buildTaskEdge({ id: "B", taskPath: ":test", durationMs: 20 }),
       ]);
 
       fixture.componentRef.setInput("requestedTasks", [":missing"]);
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      fixture.detectChanges();
-
-      expect(
-        fixture.nativeElement.querySelector(
-          '[data-testid="task-critical-path-warning"]',
-        ),
-      ).toBeFalsy();
-
-      const toggle = fixture.nativeElement.querySelector(
-        '[data-testid="task-critical-path-toggle"]',
-      ) as HTMLButtonElement;
-      toggle.click();
       fixture.detectChanges();
       await settleAsyncWork(fixture);
       fixture.detectChanges();
@@ -1426,6 +1460,11 @@ describe("TaskDependencyGraphComponent", () => {
         "choose a terminal task from the selector",
       );
       expect(warning.textContent).not.toContain("dependency cycle");
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="task-critical-path-graph"]',
+        ),
+      ).toBeFalsy();
     });
 
     it("keeps cycle warnings ahead of target warnings", async () => {
@@ -1445,7 +1484,6 @@ describe("TaskDependencyGraphComponent", () => {
       ]);
 
       component.selectCriticalPathTarget(":missing");
-      component.showCriticalPath.set(true);
       fixture.detectChanges();
       await settleAsyncWork(fixture);
       fixture.detectChanges();
@@ -1456,27 +1494,13 @@ describe("TaskDependencyGraphComponent", () => {
       expect(component.criticalPathWarning()).not.toContain("terminal task");
     });
 
-    it("renders a multiple-request warning after critical path mode is enabled", async () => {
+    it("renders a multiple-request warning in the Critical Path section", async () => {
       await render([
         buildTaskEdge({ id: "A", taskPath: ":build", durationMs: 10 }),
         buildTaskEdge({ id: "B", taskPath: ":test", durationMs: 20 }),
       ]);
 
       fixture.componentRef.setInput("requestedTasks", [":build", ":test"]);
-      fixture.detectChanges();
-      await settleAsyncWork(fixture);
-      fixture.detectChanges();
-
-      expect(
-        fixture.nativeElement.querySelector(
-          '[data-testid="task-critical-path-warning"]',
-        ),
-      ).toBeFalsy();
-
-      const toggle = fixture.nativeElement.querySelector(
-        '[data-testid="task-critical-path-toggle"]',
-      ) as HTMLButtonElement;
-      toggle.click();
       fixture.detectChanges();
       await settleAsyncWork(fixture);
       fixture.detectChanges();
@@ -1488,6 +1512,11 @@ describe("TaskDependencyGraphComponent", () => {
       expect(warning.textContent).toContain(
         "choose a terminal task from the selector",
       );
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="task-critical-path-graph"]',
+        ),
+      ).toBeFalsy();
     });
   });
 });

--- a/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
+++ b/angular/projects/build-scan-web/src/app/scans/task-dependency-graph/task-dependency-graph.component.ts
@@ -44,7 +44,7 @@ interface TaskDependencyEdge {
 
 interface TaskDependencyHighlightState {
   activeNodeId: string;
-  mode: "selected" | "critical";
+  mode: "selected";
   highlightedNodeIds: ReadonlySet<string>;
   highlightedEdgeKeys: ReadonlySet<string>;
 }
@@ -142,11 +142,6 @@ const FALLBACK_STYLE = {
   strokeColor: "oklch(55% 0.04 260)",
 };
 
-const CRITICAL_STYLE = {
-  strokeColor: "oklch(72% 0.18 70)",
-  shadowColor: "oklch(72% 0.18 70 / 0.72)",
-};
-
 const LEGEND_NODE_ITEMS: LegendNodeItem[] = [
   { label: "Success", ...SUCCESS_STYLE },
   { label: "From Cache", ...FROM_CACHE_STYLE },
@@ -235,6 +230,65 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
   return event.target?.id ?? null;
 }
 
+function buildG6TaskGraphData(graph: {
+  nodes: TaskDependencyNode[];
+  edges: TaskDependencyEdge[];
+}): G6TaskGraphData {
+  const incomingCounts = buildIncomingDependencyCounts(graph.edges);
+  const nodes = graph.nodes.map((node) => {
+    const style = getOutcomeStyle(node.outcome);
+    const incomingDependencyCount = incomingCounts.get(node.id) ?? 0;
+    return {
+      id: node.id,
+      data: {
+        label: node.label,
+        displayLabel: node.displayLabel,
+        outcome: node.outcome,
+        incomingDependencyCount,
+      },
+      style: {
+        size: getNodeSize(incomingDependencyCount),
+        fill: style.fillColor,
+        stroke: style.strokeColor,
+        lineWidth: 2,
+        labelText: node.displayLabel,
+        labelFill: "currentColor",
+        labelFontSize: 16,
+        labelFontWeight: 600,
+      },
+    };
+  });
+
+  const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
+  const edges = graph.edges.map((edge) => {
+    const targetNode = nodesById.get(edge.targetId);
+    const targetStyle = targetNode
+      ? getOutcomeStyle(targetNode.outcome)
+      : FALLBACK_STYLE;
+    return {
+      id: edgeKey(edge),
+      source: edge.sourceId,
+      target: edge.targetId,
+      data: {
+        sourceId: edge.sourceId,
+        targetId: edge.targetId,
+      },
+      style: {
+        stroke: targetStyle.strokeColor,
+        lineWidth: 2.4,
+        opacity: 0.92,
+      },
+    };
+  });
+
+  return {
+    data: { nodes, edges },
+    key: buildGraphDataKey(graph),
+    nodeIds: graph.nodes.map((node) => node.id),
+    edgeIds: graph.edges.map((edge) => edgeKey(edge)),
+  };
+}
+
 @Component({
   selector: "app-task-dependency-graph",
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -249,64 +303,9 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
             </p>
           </div>
           @if (graph().nodes.length > 0) {
-            <div class="flex flex-col items-end gap-2 text-right">
-              <div class="flex flex-col items-end gap-1">
-                <label
-                  class="text-xs font-medium uppercase tracking-wide opacity-70"
-                  for="task-critical-path-target-input"
-                >
-                  Critical path target
-                </label>
-                <input
-                  id="task-critical-path-target-input"
-                  data-testid="task-critical-path-target-input"
-                  type="text"
-                  list="task-critical-path-target-options"
-                  class="input input-sm input-bordered w-64 max-w-full font-mono text-xs"
-                  [value]="targetInputValue()"
-                  [disabled]="terminalOptions().length === 0"
-                  [attr.aria-describedby]="'task-critical-path-target-help'"
-                  [attr.aria-invalid]="criticalPathTargetInputInvalid()"
-                  (input)="selectCriticalPathTarget($any($event.target).value)"
-                  (change)="selectCriticalPathTarget($any($event.target).value)"
-                />
-                <datalist
-                  id="task-critical-path-target-options"
-                  data-testid="task-critical-path-target-options"
-                >
-                  @for (option of terminalOptions(); track option.nodeId) {
-                    <option [value]="option.label"></option>
-                  }
-                </datalist>
-                <p
-                  id="task-critical-path-target-help"
-                  data-testid="task-critical-path-target-help"
-                  class="max-w-64 text-xs"
-                  [class.opacity-60]="!criticalPathTargetInputInvalid()"
-                  [class.text-error]="criticalPathTargetInputInvalid()"
-                >
-                  {{ criticalPathTargetHelpText() }}
-                </p>
-              </div>
-              <button
-                data-testid="task-critical-path-toggle"
-                type="button"
-                class="btn btn-sm border-base-300 shadow-none"
-                [class.btn-warning]="showCriticalPath()"
-                [class.btn-outline]="!showCriticalPath()"
-                [attr.aria-pressed]="showCriticalPath()"
-                (click)="toggleCriticalPath()"
-              >
-                @if (showCriticalPath()) {
-                  Critical path highlighted
-                } @else {
-                  Highlight critical path
-                }
-              </button>
-              <div class="text-xs opacity-60">
-                {{ graph().nodes.length }} nodes ·
-                {{ graph().edges.length }} edges
-              </div>
+            <div class="text-right text-xs opacity-60">
+              {{ graph().nodes.length }} nodes ·
+              {{ graph().edges.length }} edges
             </div>
           }
         </div>
@@ -335,6 +334,90 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
             </div>
           </div>
 
+          @if (!hiddenForLargeGraph()) {
+            <div
+              class="overflow-hidden rounded-box border border-base-300 bg-base-100/40 p-3"
+            >
+              <div
+                #graphContainer
+                data-testid="task-dependency-graph"
+                class="task-dependency-g6 h-[36rem] min-h-[32rem] w-full touch-none select-none text-base-content"
+              ></div>
+            </div>
+          } @else {
+            <div
+              data-testid="task-dependency-graph-hidden"
+              class="rounded-box border border-base-300 bg-base-100/40 p-3 text-sm"
+            >
+              <div class="font-semibold">Full graph hidden</div>
+              <p class="mt-1 opacity-70">
+                The full dependency graph is hidden for this large scan. Use the
+                Critical Path section below or render the full graph anyway.
+              </p>
+            </div>
+          }
+        } @else {
+          <p class="text-sm opacity-60">No task dependency graph available.</p>
+        }
+      </div>
+    </div>
+
+    @if (graph().nodes.length > 0) {
+      <div class="card bg-base-200 mb-6">
+        <div class="card-body p-4">
+          <div class="mb-3 flex items-start justify-between gap-4">
+            <div>
+              <h4 class="font-semibold">Critical Path</h4>
+              <p class="text-xs opacity-60">
+                Render only the longest dependency chain for a terminal task.
+              </p>
+            </div>
+            <div class="flex flex-col items-end gap-1 text-right">
+              <label
+                class="text-xs font-medium uppercase tracking-wide opacity-70"
+                for="task-critical-path-target-input"
+              >
+                Critical path target
+              </label>
+              <input
+                id="task-critical-path-target-input"
+                data-testid="task-critical-path-target-input"
+                type="text"
+                list="task-critical-path-target-options"
+                class="input input-sm input-bordered w-64 max-w-full font-mono text-xs"
+                [value]="targetInputValue()"
+                [disabled]="terminalOptions().length === 0"
+                [attr.aria-describedby]="'task-critical-path-target-help'"
+                [attr.aria-invalid]="criticalPathTargetInputInvalid()"
+                (input)="selectCriticalPathTarget($any($event.target).value)"
+                (change)="selectCriticalPathTarget($any($event.target).value)"
+              />
+              <datalist
+                id="task-critical-path-target-options"
+                data-testid="task-critical-path-target-options"
+              >
+                @for (option of terminalOptions(); track option.nodeId) {
+                  <option [value]="option.label"></option>
+                }
+              </datalist>
+              <p
+                id="task-critical-path-target-help"
+                data-testid="task-critical-path-target-help"
+                class="max-w-64 text-xs"
+                [class.opacity-60]="!criticalPathTargetInputInvalid()"
+                [class.text-error]="criticalPathTargetInputInvalid()"
+              >
+                {{ criticalPathTargetHelpText() }}
+              </p>
+              @if (!criticalPathWarning()) {
+                <div class="text-xs opacity-60">
+                  {{ criticalPathGraphData().nodeIds.length }} nodes ·
+                  {{ criticalPathGraphData().edgeIds.length }} edges
+                </div>
+              }
+            </div>
+          </div>
+
           @if (criticalPathWarning()) {
             <div
               data-testid="task-critical-path-warning"
@@ -342,22 +425,20 @@ function getNodeIdFromEvent(event: IElementEvent): string | null {
             >
               {{ criticalPathWarning() }}
             </div>
-          }
-
-          <div
-            class="overflow-hidden rounded-box border border-base-300 bg-base-100/40 p-3"
-          >
+          } @else if (criticalPathGraphData().nodeIds.length > 0) {
             <div
-              #graphContainer
-              data-testid="task-dependency-graph"
-              class="task-dependency-g6 h-[36rem] min-h-[32rem] w-full touch-none select-none text-base-content"
-            ></div>
-          </div>
-        } @else {
-          <p class="text-sm opacity-60">No task dependency graph available.</p>
-        }
+              class="overflow-hidden rounded-box border border-base-300 bg-base-100/40 p-3"
+            >
+              <div
+                #criticalPathGraphContainer
+                data-testid="task-critical-path-graph"
+                class="task-dependency-g6 h-[28rem] min-h-[24rem] w-full touch-none select-none text-base-content"
+              ></div>
+            </div>
+          }
+        </div>
       </div>
-    </div>
+    }
   `,
 })
 export class TaskDependencyGraphComponent {
@@ -367,6 +448,9 @@ export class TaskDependencyGraphComponent {
   readonly edgeKey = edgeKey;
 
   private graphContainer = viewChild<ElementRef<HTMLElement>>("graphContainer");
+  private criticalPathGraphContainer = viewChild<ElementRef<HTMLElement>>(
+    "criticalPathGraphContainer",
+  );
   private destroyRef = inject(DestroyRef);
   private g6Graph: Graph | null = null;
   private g6ContainerElement: HTMLElement | null = null;
@@ -374,11 +458,16 @@ export class TaskDependencyGraphComponent {
   private pendingGraphKey: string | null = null;
   private renderRequestId = 0;
   private hasSyncedActiveElementStates = false;
+  private criticalPathG6Graph: Graph | null = null;
+  private criticalPathG6ContainerElement: HTMLElement | null = null;
+  private lastRenderedCriticalPathGraphKey: string | null = null;
+  private pendingCriticalPathGraphKey: string | null = null;
+  private criticalPathRenderRequestId = 0;
   private selectedNodeId = signal<string | null>(null);
   readonly targetInputValue = signal<string>("");
   private selectedTerminalNodeId = signal<string | null>(null);
   private userModifiedTarget = signal(false);
-  showCriticalPath = signal(false);
+  readonly hiddenForLargeGraph = input(false);
   readonly terminalOptions = computed<CriticalPathTargetOption[]>(() => {
     const graph = this.graph();
     const sourceNodeIds = new Set(graph.edges.map((edge) => edge.sourceId));
@@ -444,6 +533,7 @@ export class TaskDependencyGraphComponent {
   constructor() {
     this.destroyRef.onDestroy(() => {
       this.destroyGraph();
+      this.destroyCriticalPathGraph();
     });
 
     afterRenderEffect(() => {
@@ -484,23 +574,54 @@ export class TaskDependencyGraphComponent {
 
       const containerRef = this.graphContainer();
       const graphData = this.g6GraphData();
-      if (!containerRef || graphData.nodeIds.length === 0) {
+      if (
+        !containerRef ||
+        graphData.nodeIds.length === 0 ||
+        this.hiddenForLargeGraph()
+      ) {
         this.destroyGraph();
+      } else {
+        const container = containerRef.nativeElement;
+        if (
+          !(
+            this.g6Graph &&
+            this.g6ContainerElement === container &&
+            this.lastRenderedGraphKey === graphData.key
+          ) &&
+          this.pendingGraphKey !== graphData.key
+        ) {
+          this.pendingGraphKey = graphData.key;
+          void this.renderG6Graph(container, graphData);
+        }
+      }
+
+      const criticalPathContainerRef = this.criticalPathGraphContainer();
+      const criticalPathGraphData = this.criticalPathGraphData();
+      if (
+        !criticalPathContainerRef ||
+        criticalPathGraphData.nodeIds.length === 0 ||
+        this.criticalPathWarning()
+      ) {
+        this.destroyCriticalPathGraph();
         return;
       }
 
-      const container = containerRef.nativeElement;
+      const criticalPathContainer = criticalPathContainerRef.nativeElement;
       if (
-        this.g6Graph &&
-        this.g6ContainerElement === container &&
-        this.lastRenderedGraphKey === graphData.key
+        this.criticalPathG6Graph &&
+        this.criticalPathG6ContainerElement === criticalPathContainer &&
+        this.lastRenderedCriticalPathGraphKey === criticalPathGraphData.key
       ) {
         return;
       }
-      if (this.pendingGraphKey === graphData.key) return;
+      if (this.pendingCriticalPathGraphKey === criticalPathGraphData.key)
+        return;
 
-      this.pendingGraphKey = graphData.key;
-      void this.renderG6Graph(container, graphData);
+      this.pendingCriticalPathGraphKey = criticalPathGraphData.key;
+      void this.renderCriticalPathG6Graph(
+        criticalPathContainer,
+        criticalPathGraphData,
+      );
     });
 
     afterRenderEffect(() => {
@@ -679,102 +800,47 @@ export class TaskDependencyGraphComponent {
     };
   });
 
-  criticalPathHasCycle = computed(
-    () => this.showCriticalPath() && this.criticalPathState().hasCycle,
-  );
+  criticalPathHasCycle = computed(() => this.criticalPathState().hasCycle);
 
   criticalPathWarning = computed(() => {
-    if (!this.showCriticalPath()) {
-      return null;
-    }
+    if (this.graph().nodes.length === 0) return null;
 
     const criticalPathState = this.criticalPathState();
     if (criticalPathState.hasCycle) {
-      return "Critical path highlighting is unavailable because this graph contains a dependency cycle.";
+      return "Critical path is unavailable because this graph contains a dependency cycle.";
     }
 
     if (this.criticalPathTargetInputInvalid()) {
-      return "Critical path highlighting is unavailable because the target must match exactly one terminal task.";
+      return "Critical path is unavailable because the target must match exactly one terminal task.";
     }
 
     if (!this.effectiveCriticalPathTargetNodeId()) {
-      return "Critical path highlighting is unavailable because you must choose a terminal task from the selector.";
+      return "Critical path is unavailable because you must choose a terminal task from the selector.";
     }
 
     return null;
   });
 
-  private g6GraphData = computed<G6TaskGraphData>(() => {
+  private g6GraphData = computed<G6TaskGraphData>(() =>
+    buildG6TaskGraphData(this.graph()),
+  );
+
+  readonly criticalPathGraphData = computed<G6TaskGraphData>(() => {
     const graph = this.graph();
-    const incomingCounts = buildIncomingDependencyCounts(graph.edges);
-    const nodes = graph.nodes.map((node) => {
-      const style = getOutcomeStyle(node.outcome);
-      const incomingDependencyCount = incomingCounts.get(node.id) ?? 0;
-      return {
-        id: node.id,
-        data: {
-          label: node.label,
-          displayLabel: node.displayLabel,
-          outcome: node.outcome,
-          incomingDependencyCount,
-        },
-        style: {
-          size: getNodeSize(incomingDependencyCount),
-          fill: style.fillColor,
-          stroke: style.strokeColor,
-          lineWidth: 2,
-          labelText: node.displayLabel,
-          labelFill: "currentColor",
-          labelFontSize: 16,
-          labelFontWeight: 600,
-        },
-      };
-    });
-
-    const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
-    const edges = graph.edges.map((edge) => {
-      const targetNode = nodesById.get(edge.targetId);
-      const targetStyle = targetNode
-        ? getOutcomeStyle(targetNode.outcome)
-        : FALLBACK_STYLE;
-      return {
-        id: edgeKey(edge),
-        source: edge.sourceId,
-        target: edge.targetId,
-        data: {
-          sourceId: edge.sourceId,
-          targetId: edge.targetId,
-        },
-        style: {
-          stroke: targetStyle.strokeColor,
-          lineWidth: 2.4,
-          opacity: 0.92,
-        },
-      };
-    });
-
-    return {
-      data: { nodes, edges },
-      key: buildGraphDataKey(graph),
-      nodeIds: graph.nodes.map((node) => node.id),
-      edgeIds: graph.edges.map((edge) => edgeKey(edge)),
-    };
+    const criticalPathState = this.criticalPathState();
+    const nodes = graph.nodes.filter((node) =>
+      criticalPathState.nodeIds.has(node.id),
+    );
+    const edges = graph.edges.filter(
+      (edge) =>
+        criticalPathState.edgeKeys.has(edgeKey(edge)) &&
+        criticalPathState.nodeIds.has(edge.sourceId) &&
+        criticalPathState.nodeIds.has(edge.targetId),
+    );
+    return buildG6TaskGraphData({ nodes, edges });
   });
 
   highlightState = computed<TaskDependencyHighlightState | null>(() => {
-    if (this.showCriticalPath()) {
-      if (this.criticalPathTargetInputInvalid()) return null;
-      const criticalPath = this.criticalPathState();
-      const [activeNodeId] = criticalPath.nodeIds;
-      if (criticalPath.hasCycle || !activeNodeId) return null;
-      return {
-        activeNodeId,
-        mode: "critical",
-        highlightedNodeIds: criticalPath.nodeIds,
-        highlightedEdgeKeys: criticalPath.edgeKeys,
-      };
-    }
-
     const activeNodeId = this.selectedNodeIdInGraph();
     if (!activeNodeId) return null;
 
@@ -821,10 +887,6 @@ export class TaskDependencyGraphComponent {
     this.selectedNodeId.set(null);
   }
 
-  toggleCriticalPath(): void {
-    this.showCriticalPath.update((isShown) => !isShown);
-  }
-
   selectCriticalPathTarget(typedValue: string | null): void {
     this.userModifiedTarget.set(true);
     this.targetInputValue.set(typedValue ?? "");
@@ -842,16 +904,9 @@ export class TaskDependencyGraphComponent {
     return this.terminalOptions().some((option) => option.nodeId === nodeId);
   }
 
-  nodeHighlightState(
-    nodeId: string,
-  ): "idle" | "highlighted" | "critical" | "dimmed" {
+  nodeHighlightState(nodeId: string): "idle" | "highlighted" | "dimmed" {
     const highlightState = this.highlightState();
     if (!highlightState) return "idle";
-    if (highlightState.mode === "critical") {
-      return highlightState.highlightedNodeIds.has(nodeId)
-        ? "critical"
-        : "dimmed";
-    }
     return highlightState.highlightedNodeIds.has(nodeId)
       ? "highlighted"
       : "dimmed";
@@ -859,13 +914,10 @@ export class TaskDependencyGraphComponent {
 
   edgeHighlightState(
     edge: TaskDependencyEdge,
-  ): "idle" | "highlighted" | "critical" | "dimmed" {
+  ): "idle" | "highlighted" | "dimmed" {
     const highlightState = this.highlightState();
     if (!highlightState) return "idle";
     const isHighlighted = highlightState.highlightedEdgeKeys.has(edgeKey(edge));
-    if (highlightState.mode === "critical") {
-      return isHighlighted ? "critical" : "dimmed";
-    }
     return isHighlighted ? "highlighted" : "dimmed";
   }
 
@@ -892,6 +944,41 @@ export class TaskDependencyGraphComponent {
     if (this.pendingGraphKey === graphData.key) this.pendingGraphKey = null;
     await graph.fitView();
     this.syncG6ElementStates();
+  }
+
+  private async renderCriticalPathG6Graph(
+    container: HTMLElement,
+    graphData: G6TaskGraphData,
+  ): Promise<void> {
+    const requestId = ++this.criticalPathRenderRequestId;
+    if (
+      !this.criticalPathG6Graph ||
+      this.criticalPathG6ContainerElement !== container
+    ) {
+      this.destroyCriticalPathGraph(false);
+      this.criticalPathG6ContainerElement = container;
+      this.criticalPathG6Graph = new Graph(
+        this.buildGraphOptions(container, graphData),
+      );
+    } else {
+      this.criticalPathG6Graph.setData(graphData.data);
+      this.criticalPathG6Graph.setLayout(TASK_GRAPH_LAYOUT);
+    }
+
+    const graph = this.criticalPathG6Graph;
+    await graph.render();
+    if (
+      requestId !== this.criticalPathRenderRequestId ||
+      this.criticalPathG6Graph !== graph
+    ) {
+      return;
+    }
+
+    this.lastRenderedCriticalPathGraphKey = graphData.key;
+    if (this.pendingCriticalPathGraphKey === graphData.key) {
+      this.pendingCriticalPathGraphKey = null;
+    }
+    await graph.fitView();
   }
 
   private buildGraphOptions(
@@ -926,12 +1013,6 @@ export class TaskDependencyGraphComponent {
           selected: {
             lineWidth: 4,
           },
-          critical: {
-            stroke: CRITICAL_STYLE.strokeColor,
-            lineWidth: 5,
-            shadowBlur: 18,
-            shadowColor: CRITICAL_STYLE.shadowColor,
-          },
           dimmed: {
             opacity: 0.28,
             labelOpacity: 0.36,
@@ -948,11 +1029,6 @@ export class TaskDependencyGraphComponent {
             lineWidth: 3,
             opacity: 1,
           },
-          critical: {
-            stroke: CRITICAL_STYLE.strokeColor,
-            lineWidth: 5,
-            opacity: 1,
-          },
           dimmed: {
             opacity: 0.12,
           },
@@ -963,12 +1039,10 @@ export class TaskDependencyGraphComponent {
 
   private bindGraphEvents(graph: Graph): void {
     graph.on(NodeEvent.CLICK, (event: IElementEvent) => {
-      if (this.showCriticalPath()) return;
       const nodeId = getNodeIdFromEvent(event);
       if (nodeId) this.selectNode(nodeId);
     });
     graph.on(CanvasEvent.CLICK, () => {
-      if (this.showCriticalPath()) return;
       this.clearSelectedNode();
     });
   }
@@ -997,9 +1071,7 @@ export class TaskDependencyGraphComponent {
 
     for (const nodeId of graphData.nodeIds) {
       const state = this.nodeHighlightState(nodeId);
-      if (state === "critical") {
-        states[nodeId] = ["critical"];
-      } else if (state === "highlighted") {
+      if (state === "highlighted") {
         states[nodeId] =
           highlightState?.mode === "selected" &&
           highlightState.activeNodeId === nodeId
@@ -1029,5 +1101,15 @@ export class TaskDependencyGraphComponent {
     if (!this.g6Graph) return;
     this.g6Graph.destroy();
     this.g6Graph = null;
+  }
+
+  private destroyCriticalPathGraph(cancelPendingRender = true): void {
+    if (cancelPendingRender) this.criticalPathRenderRequestId += 1;
+    this.lastRenderedCriticalPathGraphKey = null;
+    this.pendingCriticalPathGraphKey = null;
+    this.criticalPathG6ContainerElement = null;
+    if (!this.criticalPathG6Graph) return;
+    this.criticalPathG6Graph.destroy();
+    this.criticalPathG6Graph = null;
   }
 }


### PR DESCRIPTION
## Summary
- split critical path rendering into its own always-visible section
- render only critical-path nodes and edges in the Critical Path graph
- keep the Critical Path section available when the full task dependency graph is hidden for large scans

## Verification
- bazel run gazelle
- bazel run //tools/format
- aspect lint //...
- aspect test //...
- aspect build //...
- aspect test //angular/projects/build-scan-web:test
- agent-browser QA against a live scan: full graph showed 61 nodes / 142 edges; Critical Path showed 12 nodes / 11 edges; old toggle absent
