### PR TITLE
chore: repin Maven lockfile in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,15 @@
   },
   "packageRules": [
     {
+      "matchManagers": ["bazel-module"],
+      "matchDatasources": ["maven"],
+      "postUpgradeTasks": {
+        "commands": ["env REPIN=1 bazel run @maven//:pin"],
+        "fileFilters": ["maven_install.json"],
+        "executionMode": "update"
+      }
+    },
+    {
       "matchManagers": ["cargo"],
       "postUpgradeTasks": {
         "commands": ["bazel mod deps --lockfile_mode=update"],
@@ -18,7 +27,7 @@
       }
     },
     {
-      "matchManagers": ["bazel_module"],
+      "matchManagers": ["bazel-module"],
       "matchPackageNames": ["bazelrc-preset"],
       "postUpgradeTasks": {
         "commands": ["bazel run @@//tools:preset.update"],


### PR DESCRIPTION
## Summary
- add a Renovate Bazel-module Maven package rule that runs `env REPIN=1 bazel run @maven//:pin`
- include `maven_install.json` in the post-upgrade file filters
- normalize the existing `bazelrc-preset` Renovate manager name to `bazel-module`

## Validation
- `python -m json.tool renovate.json`
- `bazel run gazelle`
- `bazel run //tools/format`
- `aspect lint //...`
- `aspect test //...`
- `aspect build //...`
